### PR TITLE
Implement the clone command

### DIFF
--- a/src/FuseDigital.QuickSetup.Application/IQupCommandAsync.cs
+++ b/src/FuseDigital.QuickSetup.Application/IQupCommandAsync.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace FuseDigital.QuickSetup;
+
+public interface IQupCommandAsync
+{
+    Task ExecuteAsync(IQupCommandOptions options);
+}

--- a/src/FuseDigital.QuickSetup.Application/IQupCommandOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/IQupCommandOptions.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace FuseDigital.QuickSetup;
+
+public interface IQupCommandOptions
+{
+    Type GetCommandType();
+}

--- a/src/FuseDigital.QuickSetup.Application/Projects/CloneCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/Projects/CloneCommand.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using FuseDigital.QuickSetup.VersionControlSystems;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+
+namespace FuseDigital.QuickSetup.Projects;
+
+public class CloneCommand : QupCommandAsync, ITransientDependency
+{
+    private readonly QuickSetupOptions _options;
+    private readonly IProjectRepository _repository;
+    private readonly IVersionControlDomainService _sourceControl;
+
+    public CloneCommand(IOptions<QuickSetupOptions> options,
+        IProjectRepository repository,
+        IVersionControlDomainService sourceControl)
+    {
+        _options = options.Value;
+        _repository = repository;
+        _sourceControl = sourceControl;
+    }
+
+    public override async Task ExecuteAsync(IQupCommandOptions options)
+    {
+        var cloneOptions = (CloneOptions)options;
+        var project = new Project
+        {
+            Repository = cloneOptions.Repository,
+            RelativePath = _options.GetRelativePath(cloneOptions.LocalFolder),
+        };
+
+        var exist = await _repository.FindAsync(src => src.RelativePath.Equals(project.RelativePath));
+        if (exist != null)
+        {
+            const string message = "The working directory {0} is already being tracked";
+            Logger.LogInformation(message, project.RelativePath);
+            Console.WriteLine(message, project.RelativePath);
+            return;
+        }
+
+        project.Clone(_sourceControl);
+        await _repository.InsertAsync(project);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/Projects/CloneOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/Projects/CloneOptions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+using CommandLine;
+
+namespace FuseDigital.QuickSetup.Projects;
+
+[Verb("clone", HelpText = "The clone command allows you to download a copy of a Git source repository to your local machine. It automatically saves the repository information and sets up synchronization, so that you can easily work with the repository across multiple machines.")]
+public class CloneOptions : IQupCommandOptions
+{
+    [Value(0, Required = true, HelpText = "The URL of the repository to clone.")]
+    public string Repository { get; set; }
+    
+    [Value(1, Required = true, HelpText = "The directory to clone the repository into.")]
+    public string LocalFolder { get; set; }
+
+    public Type GetCommandType()
+    {
+        return typeof(CloneCommand);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/QuickSetupAppService.cs
+++ b/src/FuseDigital.QuickSetup.Application/QuickSetupAppService.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using CommandLine;
+using CommandLine.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.Application.Services;
@@ -14,13 +20,44 @@ public class QuickSetupAppService : ApplicationService
         _options = options.Value;
     }
 
-    public Task RunAsync(string[] args)
+    public async Task RunAsync(IEnumerable<string> args)
     {
         Logger.LogInformation("Quick Setup CLI (https://github.com/fuse-digital/quick-setup)");
-        Logger.LogInformation("User profile directory is set {0}", _options.UserProfile);
-        Logger.LogInformation("The base directory for QUP is set {0}", _options.BaseDirectory);
-        Logger.LogInformation("The system directory separator is set to {0}", _options.DirectorySeparatorChar);
+        Logger.LogInformation("User profile directory is set {UserProfile}", _options.UserProfile);
+        Logger.LogInformation("The base directory for QUP is set {BaseDirectory}", _options.BaseDirectory);
         
+        var parser = new CommandLine.Parser(with => with.HelpWriter = null);
+        var parserResult = parser.ParseArguments(args, GetOptions());
+        await parserResult.WithParsedAsync<IQupCommandOptions>(RunCommandAsync);
+        await parserResult.WithNotParsedAsync(errors => DisplayHelpAsync(parserResult, errors));
+    }
+
+    private Task DisplayHelpAsync<T>(ParserResult<T> result, IEnumerable<Error> errors)
+    {
+        var helpText = HelpText.AutoBuild(result, h =>
+        {
+            h.AdditionalNewLineAfterOption = false;
+            h.Heading = "QUP 0.1-beta";
+            h.Copyright = $"Copyright (c) {DateTime.Now.Year} Fuse Digital (PTY) Limited";
+            return HelpText.DefaultParsingErrorsHandler(result, h);
+        }, e => e);
+        Console.WriteLine(helpText);
+
         return Task.CompletedTask;
+    }
+
+    private async Task RunCommandAsync(IQupCommandOptions options)
+    {
+        var command = (IQupCommandAsync) LazyServiceProvider.LazyGetRequiredService(options.GetCommandType());
+        await command.ExecuteAsync(options);
+    }
+
+    private static Type[] GetOptions()
+    {
+        return Assembly.GetExecutingAssembly().GetTypes()
+            .Where(t =>
+                t.GetInterfaces().Any(i => i.IsAssignableFrom(typeof(IQupCommandOptions)))
+                && t.GetCustomAttribute<VerbAttribute>() != null)
+            .ToArray();
     }
 }

--- a/src/FuseDigital.QuickSetup.Application/QupCommandAsync.cs
+++ b/src/FuseDigital.QuickSetup.Application/QupCommandAsync.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Volo.Abp.DependencyInjection;
+
+namespace FuseDigital.QuickSetup;
+
+public abstract class QupCommandAsync : IQupCommandAsync
+{
+    public IAbpLazyServiceProvider LazyServiceProvider { get; set; }
+
+    protected ILoggerFactory LoggerFactory => LazyServiceProvider.LazyGetRequiredService<ILoggerFactory>();
+
+    protected ILogger Logger => LazyServiceProvider
+        .LazyGetService<ILogger>(provider => LoggerFactory?
+            .CreateLogger(GetType().FullName) ?? NullLogger.Instance);
+
+    public abstract Task ExecuteAsync(IQupCommandOptions options);
+}

--- a/src/FuseDigital.QuickSetup.Cli/FuseDigital.QuickSetup.Cli.csproj
+++ b/src/FuseDigital.QuickSetup.Cli/FuseDigital.QuickSetup.Cli.csproj
@@ -12,18 +12,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0"/>
-        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0"/>
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0"/>
+        <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Volo.Abp.Autofac" Version="6.0.2"/>
+        <PackageReference Include="Volo.Abp.Autofac" Version="6.0.2" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\FuseDigital.QuickSetup.Application\FuseDigital.QuickSetup.Application.csproj"/>
+        <ProjectReference Include="..\FuseDigital.QuickSetup.Application\FuseDigital.QuickSetup.Application.csproj" />
+        <ProjectReference Include="..\FuseDigital.QuickSetup.Yaml\FuseDigital.QuickSetup.Yaml.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/FuseDigital.QuickSetup.Cli/QuickSetupCliModule.cs
+++ b/src/FuseDigital.QuickSetup.Cli/QuickSetupCliModule.cs
@@ -7,6 +7,7 @@ namespace FuseDigital.QuickSetup.Cli;
 
 [DependsOn(
     typeof(QuickSetupApplicationModule),
+    typeof(QuickSetupYamlModule),
     typeof(AbpAutofacModule)
 )]
 public class QuickSetupCliModule : AbpModule

--- a/src/FuseDigital.QuickSetup.Domain/Projects/IProjectRepository.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Projects/IProjectRepository.cs
@@ -1,0 +1,7 @@
+﻿using Volo.Abp.Domain.Repositories;
+
+namespace FuseDigital.QuickSetup.Projects;
+
+public interface IProjectRepository : IRepository<Project>
+{
+}

--- a/src/FuseDigital.QuickSetup.Domain/Projects/Project.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Projects/Project.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel.DataAnnotations;
+using FuseDigital.QuickSetup.VersionControlSystems;
+using Volo.Abp.Domain.Entities;
+
+namespace FuseDigital.QuickSetup.Projects;
+
+public class Project : Entity
+{
+    [Key]
+    public string RelativePath { get; set; }
+
+    public string Repository { get; set; }
+
+    public override object[] GetKeys()
+    {
+        return new object[] {RelativePath};
+    }
+
+    public void Clone(IVersionControlDomainService versionControl)
+    {
+        versionControl.Clone(Repository, RelativePath);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/QuickSetupOptions.cs
+++ b/src/FuseDigital.QuickSetup.Domain/QuickSetupOptions.cs
@@ -6,5 +6,21 @@ public class QuickSetupOptions
 
     public string BaseDirectory { get; set; } = ".qup";
 
-    public char DirectorySeparatorChar  { get; set; } = '/';
+    public const char DirectorySeparatorChar = '/';
+
+    public const string UserProfileChar = "~";
+
+    public string GetAbsolutePath(string path)
+    {
+        return (path.Equals(".") ? Environment.CurrentDirectory : path)
+            .Replace(UserProfileChar, UserProfile)
+            .Replace(DirectorySeparatorChar, Path.DirectorySeparatorChar);
+    }
+
+    public string GetRelativePath(string path)
+    {
+        return (path.Equals(".") ? Environment.CurrentDirectory : path)
+            .Replace(UserProfile, UserProfileChar)
+            .Replace(Path.DirectorySeparatorChar, DirectorySeparatorChar);
+    }
 }

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
@@ -1,0 +1,8 @@
+using Volo.Abp.Domain.Services;
+
+namespace FuseDigital.QuickSetup.VersionControlSystems;
+
+public interface IVersionControlDomainService : IDomainService
+{
+    void Clone(string sourceUrl, string relativePath);
+}

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.Domain.Services;
+
+namespace FuseDigital.QuickSetup.VersionControlSystems;
+
+public class VersionControlDomainService : DomainService, IVersionControlDomainService
+{
+    private readonly QuickSetupOptions _options;
+
+    public VersionControlDomainService(IOptions<QuickSetupOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public void Clone(string sourceUrl, string relativePath)
+    {
+        var workingDirectory = _options.GetAbsolutePath(relativePath);
+        Logger.LogInformation("The absolute path is {AbsolutePath}", workingDirectory);
+        Logger.LogInformation("Cloning {Repository} into {RelativePath}", sourceUrl, relativePath);
+        RunGitCommand(new[] { "clone", sourceUrl, relativePath });
+    }
+
+    private static void RunGitCommand(IEnumerable<string> args)
+    {
+        var startInfo = GitCommand(args);
+        var process = Process.Start(startInfo);
+        process?.WaitForExit();
+    }
+
+    private static ProcessStartInfo GitCommand(IEnumerable<string> args)
+    {
+        var arguments = args
+            .Select(x => x.Contains(" ") ? $"\"{x}\"" : x)
+            .JoinAsString(" ");
+
+        return new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = arguments,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+        };
+    }
+}

--- a/src/FuseDigital.QuickSetup.Yaml/Repositories/ProjectRepositories.cs
+++ b/src/FuseDigital.QuickSetup.Yaml/Repositories/ProjectRepositories.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using FuseDigital.QuickSetup.Projects;
+using FuseDigital.QuickSetup.Yaml;
+
+namespace FuseDigital.QuickSetup.Repositories;
+
+public class ProjectRepository : YamlRepository<Project>, IProjectRepository
+{
+    public ProjectRepository(IYamlContext context) : base(context)
+    {
+    }
+
+    public override Func<Project, object> SortOrder<TKey>() => project => project.RelativePath;
+}

--- a/test/FuseDigital.QuickSetup.Application.Tests/FuseDigital.QuickSetup.Application.Tests.csproj
+++ b/test/FuseDigital.QuickSetup.Application.Tests/FuseDigital.QuickSetup.Application.Tests.csproj
@@ -15,5 +15,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Include="Projects\project-exists.yml" />
+  </ItemGroup>
 
 </Project>

--- a/test/FuseDigital.QuickSetup.Application.Tests/Projects/CloneCommandTests.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/Projects/CloneCommandTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.Repositories;
+using FuseDigital.QuickSetup.VersionControlSystems;
+using FuseDigital.QuickSetup.Yaml;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Volo.Abp.DependencyInjection;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.Projects;
+
+public class CloneCommandTests : QuickSetupApplicationTestBase
+{
+    private readonly string _basePath;
+
+    public CloneCommandTests()
+    {
+        _basePath = Guid.NewGuid().ToString();
+    }
+
+    [Fact]
+    public async Task Should_Not_Clone_If_Project_Already_Exists()
+    {
+        // Arrange
+        var repository = GetRepository();
+        var options = GetRequiredService<IOptions<QuickSetupOptions>>();
+        var versionControl = A.Fake<IVersionControlDomainService>();
+        var command = new CloneCommand(options, repository, versionControl)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        var commandOptions = new CloneOptions
+        {
+            LocalFolder = "~/organization/project/repository",
+            Repository = "git@ssh.dev.azure.com:v3/organization/project/repository",
+        };
+        await CopyFileAsync("project-exists.yml", repository.FilePath);
+
+        // Act
+        await command.ExecuteAsync(commandOptions);
+
+        // Assert
+        A.CallTo(() => versionControl
+                .Clone(commandOptions.Repository, commandOptions.LocalFolder))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Add_Project_If_It_Does_Not_Exists()
+    {
+        // Arrange
+        var repository = GetRepository();
+        var options = GetRequiredService<IOptions<QuickSetupOptions>>();
+        var versionControl = A.Fake<IVersionControlDomainService>();
+        var command = new CloneCommand(options, repository, versionControl)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+        var commandOptions = new CloneOptions
+        {
+            LocalFolder = "~/organization/project/repository",
+            Repository = "git@ssh.dev.azure.com:v3/organization/project/repository",
+        };
+
+        // Act
+        await command.ExecuteAsync(commandOptions);
+
+        // Assert
+        A.CallTo(() => versionControl.Clone(commandOptions.Repository, commandOptions.LocalFolder))
+            .MustHaveHappened();
+
+        var entity = await repository.FindAsync(x => x.RelativePath.Equals(commandOptions.LocalFolder));
+        entity.ShouldNotBeNull();
+    }
+
+    private ProjectRepository GetRepository(IYamlContext context = default)
+    {
+        return new ProjectRepository(context ?? GetContext(_basePath))
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>()
+        };
+    }
+
+    public override void Dispose()
+    {
+        var context = GetRequiredService<IYamlContext>();
+        var path = Path.Combine(context.Options.UserProfile, _basePath);
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, true);
+        }
+
+        base.Dispose();
+    }
+}

--- a/test/FuseDigital.QuickSetup.Application.Tests/Projects/project-exists.yml
+++ b/test/FuseDigital.QuickSetup.Application.Tests/Projects/project-exists.yml
@@ -1,0 +1,2 @@
+﻿- relative-path: ~/organization/project/repository
+  repository: git@ssh.dev.azure.com:v3/organization/project/repository

--- a/test/FuseDigital.QuickSetup.Application.Tests/QuickSetupApplicationTestBase.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/QuickSetupApplicationTestBase.cs
@@ -1,5 +1,58 @@
-﻿namespace FuseDigital.QuickSetup;
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using FuseDigital.QuickSetup.Yaml;
+
+namespace FuseDigital.QuickSetup;
 
 public abstract class QuickSetupApplicationTestBase : QuickSetupTestBase<QuickSetupApplicationTestModule>
 {
+    protected IYamlContext GetContext(string basePath)
+    {
+        var context = GetRequiredService<IYamlContext>();
+        var folder = GetTestMethodName() ?? Guid.NewGuid().ToString();
+        context.Options.BaseDirectory = Path.Combine(basePath, folder);
+
+        return context;
+    }
+
+    private string GetTestMethodName()
+    {
+        return new StackTrace()
+            .GetFrames()
+            .FirstOrDefault(x => x.GetMethod()!.Name.Contains("_"))
+            ?.GetMethod()
+            ?.Name;
+    }
+
+    protected string GetFileContents(string fileName)
+    {
+        var fullyQualifiedName = $"{GetType().Namespace}.{fileName}";
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(fullyQualifiedName);
+        if (stream == null)
+        {
+            return null;
+        }
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+    
+    protected async Task CopyFileAsync(string source, string destination)
+    {
+        var content = GetFileContents(source);
+        if (content != null)
+        {
+            var directoryFullName = new FileInfo(destination).Directory?.FullName;
+            if (directoryFullName != null)
+            {
+                Directory.CreateDirectory(directoryFullName);
+            }
+
+            await File.WriteAllTextAsync(destination, content);
+        }
+    }
 }

--- a/test/FuseDigital.QuickSetup.Domain.Tests/FuseDigital.QuickSetup.Domain.Tests.csproj
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/FuseDigital.QuickSetup.Domain.Tests.csproj
@@ -13,6 +13,7 @@
   
     <ItemGroup>
         <ProjectReference Include="..\FuseDigital.QuickSetup.TestBase\FuseDigital.QuickSetup.TestBase.csproj" />
+        <ProjectReference Include="..\FuseDigital.QuickSetup.Yaml.Tests\FuseDigital.QuickSetup.Yaml.Tests.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/FuseDigital.QuickSetup.Domain.Tests/QuickSetupDomainTestModule.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/QuickSetupDomainTestModule.cs
@@ -3,8 +3,9 @@
 namespace FuseDigital.QuickSetup;
 
 [DependsOn(
-    typeof(QuickSetupTestBaseModule)
-    )]
+    typeof(QuickSetupTestBaseModule),
+    typeof(QuickSetupYamlTestModule)
+)]
 public class QuickSetupDomainTestModule : AbpModule
 {
 }

--- a/test/FuseDigital.QuickSetup.Yaml.Tests/Yaml/EntityRepositoryTests.cs
+++ b/test/FuseDigital.QuickSetup.Yaml.Tests/Yaml/EntityRepositoryTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -271,8 +270,6 @@ public class EntityRepositoryTests : QuickSetupYamlTestBase
         output.Count.ShouldBe(3);
     }
 
-    
-
     private async Task CopyFileAsync(string source, string destination)
     {
         var content = GetFileContents(source);
@@ -310,7 +307,6 @@ public class EntityRepositoryTests : QuickSetupYamlTestBase
 
     private SampleRepository GetSampleRepository(IYamlContext context = default)
     {
-        var methodName = new StackTrace().GetFrame(1)?.GetMethod()?.Name;
         return new SampleRepository(context ?? GetContext())
         {
             LazyServiceProvider = GetService<IAbpLazyServiceProvider>()


### PR DESCRIPTION

### Add a version control system domain service

Added the version control domain service interface and a concrete
implementation for Git.

### Implement plugable commands for app service

Used reflection to automatically discover commands and options that
inherit from the IQupCommandAsync and IQupCommandOptions interfaces.

Updated the quick setup application service to also handle all the
commands and argument parser errors.

### Add clone command

This command will automatically be added and track the version control
repository and local relative path, whilst also performing the clone
command.
