### PR TITLE
Feature/init command

### DIFF
--- a/.github/actions/dotnet/test/action.yml
+++ b/.github/actions/dotnet/test/action.yml
@@ -16,6 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
+
     - name: Execute unit tests
       shell: bash
       run: dotnet test --logger trx --results-directory ${{ inputs.results-directory }} --no-build --configuration ${{ inputs.dotnet-build-configuration }} --verbosity normal

--- a/src/FuseDigital.QuickSetup.Application/Projects/CloneOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/Projects/CloneOptions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using CommandLine;
 
 namespace FuseDigital.QuickSetup.Projects;
@@ -10,7 +9,7 @@ public class CloneOptions : IQupCommandOptions
     [Value(0, Required = true, HelpText = "The URL of the repository to clone.")]
     public string Repository { get; set; }
     
-    [Value(1, Required = true, HelpText = "The directory to clone the repository into.")]
+    [Value(1, Required = true, HelpText = "The local path where the repository will be cloned. This can be an absolute or relative path, and the ~ character can be used to represent the user profile folder (which is platform-agnostic).")]
     public string LocalFolder { get; set; }
 
     public Type GetCommandType()

--- a/src/FuseDigital.QuickSetup.Application/UserFiles/InitialiseCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/UserFiles/InitialiseCommand.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+public class InitialiseCommand : QupCommandAsync, ITransientDependency
+{
+    private readonly IUserFileDomainService _userFileDomainService;
+    private readonly QuickSetupOptions _options;
+
+    public InitialiseCommand(IUserFileDomainService userFileDomainService, IOptions<QuickSetupOptions> options)
+    {
+        _userFileDomainService = userFileDomainService;
+        _options = options.Value;
+    }
+
+    public override async Task ExecuteAsync(IQupCommandOptions options)
+    {
+        var init = (InitialiseOptions) options;
+
+        if (_userFileDomainService.Exists())
+        {
+            const string message = "A source repository already exists in {0}";
+            Logger.LogInformation(message, _options.UserProfile);
+            Console.WriteLine(message, _options.UserProfile);
+            return;
+        }
+
+        await _userFileDomainService.Initialise(init.Repository, init.DefaultBranchName);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/UserFiles/InitialiseOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/UserFiles/InitialiseOptions.cs
@@ -1,0 +1,19 @@
+using System;
+using CommandLine;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+[Verb("init", HelpText = "Initializes a new local git repository and pushes it to a remote repository.")]
+public class InitialiseOptions : IQupCommandOptions
+{
+    [Value(0, Required = true, HelpText = "he URL of the empty remote repository.")]
+    public string Repository { get; set; }
+    
+    [Value(1, Required = true, HelpText = "The name of the default branch for the repository.")]
+    public string DefaultBranchName { get; set; }
+
+    public Type GetCommandType()
+    {
+        return typeof(InitialiseCommand);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Cli/QuickSetupCliModule.cs
+++ b/src/FuseDigital.QuickSetup.Cli/QuickSetupCliModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using System.Runtime.InteropServices;
+using System.IO;
+using System.Reflection;
 using Volo.Abp.Autofac;
 using Volo.Abp.Modularity;
 
@@ -17,7 +18,13 @@ public class QuickSetupCliModule : AbpModule
         base.ConfigureServices(context);
         Configure<QuickSetupOptions>(options =>
         {
+#if DEBUG
+            var debugPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            options.UserProfile = Path.Combine(debugPath, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(options.UserProfile);
+#else
             options.UserProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+#endif
         });
     }
 }

--- a/src/FuseDigital.QuickSetup.Domain/FuseDigital.QuickSetup.Domain.csproj
+++ b/src/FuseDigital.QuickSetup.Domain/FuseDigital.QuickSetup.Domain.csproj
@@ -3,7 +3,7 @@
     <Import Project="..\..\common.props" />
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>FuseDigital.QuickSetup</RootNamespace>
         <IsPackable>false</IsPackable>

--- a/src/FuseDigital.QuickSetup.Domain/UserFiles/IUserFileDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/UserFiles/IUserFileDomainService.cs
@@ -1,0 +1,10 @@
+using Volo.Abp.Domain.Services;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+public interface IUserFileDomainService : IDomainService
+{
+    bool Exists();
+
+    Task Initialise(string sourceUrl, string defaultBranch);
+}

--- a/src/FuseDigital.QuickSetup.Domain/UserFiles/UserFileDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/UserFiles/UserFileDomainService.cs
@@ -1,0 +1,65 @@
+using FuseDigital.QuickSetup.VersionControlSystems;
+using Microsoft.Extensions.Options;
+using Volo.Abp;
+using Volo.Abp.Domain.Services;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+public class UserFileDomainService : DomainService, IUserFileDomainService
+{
+    private readonly IVersionControlDomainService _versionControl;
+    private readonly QuickSetupOptions _options;
+
+    public UserFileDomainService(IOptions<QuickSetupOptions> options, IVersionControlDomainService versionControl)
+    {
+        _options = options.Value;
+        _versionControl = versionControl;
+        _versionControl.WorkingDirectory = _options.UserProfile;
+    }
+
+    public bool Exists()
+    {
+        var path = Path.Combine(_options.UserProfile, _versionControl.RepositoryDirectory);
+        return Directory.Exists(path);
+    }
+
+    public async Task Initialise(string sourceUrl, string defaultBranch)
+    {
+        Check.NotNull(sourceUrl, nameof(sourceUrl));
+        Check.NotNull(defaultBranch, nameof(defaultBranch));
+        if (Exists())
+        {
+            throw new RepositoryAlreadyExistsException(_options.UserProfile);
+        }
+
+        _versionControl.Init(_options.UserProfile);
+        await CreateIgnoreFile();
+        await CreateIncludeFile();
+        _versionControl.Add(".");
+        _versionControl.Commit();
+        _versionControl.RenameBranch(defaultBranch);
+        _versionControl.AddRemote(sourceUrl);
+        _versionControl.PushSetUpstream(defaultBranch);
+    }
+
+    private async Task CreateIgnoreFile()
+    {
+        var ignore = new[]
+        {
+            "/*",
+            "!.gitignore",
+            "!.gitinclude",
+            ".DS_Store"
+        };
+        await File.WriteAllLinesAsync(Path.Combine(_options.UserProfile, ".gitignore"), ignore);
+    }
+
+    private async Task CreateIncludeFile()
+    {
+        var include = new[]
+        {
+            $"{_options.BaseDirectory}/"
+        };
+        await File.WriteAllLinesAsync(Path.Combine(_options.UserProfile, ".gitinclude"), include);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
@@ -14,6 +14,8 @@ public interface IVersionControlDomainService : IDomainService
 
     IEnumerable<string> Add(string pathSpec, IEnumerable<string> args = default);
 
+    IEnumerable<string> SetConfig(string key, string value, bool global = false);
+
     IEnumerable<string> Status(IEnumerable<string> args = default);
 
     IEnumerable<string> Commit(string message = default, IEnumerable<string> args = default);

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
@@ -4,5 +4,23 @@ namespace FuseDigital.QuickSetup.VersionControlSystems;
 
 public interface IVersionControlDomainService : IDomainService
 {
-    void Clone(string sourceUrl, string relativePath);
+    string WorkingDirectory { get; set; }
+    
+    string RepositoryDirectory { get; }
+
+    IEnumerable<string> Clone(string sourceUrl, string relativePath);
+
+    IEnumerable<string> Init(string workingDirectory, IEnumerable<string> args = default);
+
+    IEnumerable<string> Add(string pathSpec, IEnumerable<string> args = default);
+
+    IEnumerable<string> Status(IEnumerable<string> args = default);
+
+    IEnumerable<string> Commit(string message = default, IEnumerable<string> args = default);
+
+    IEnumerable<string> RenameBranch(string name, IEnumerable<string> args = default);
+
+    IEnumerable<string> AddRemote(string remoteUrl, IEnumerable<string> args = default);
+
+    IEnumerable<string> PushSetUpstream(string branch, IEnumerable<string> args = default);
 }

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/RepositoryAlreadyExistsException.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/RepositoryAlreadyExistsException.cs
@@ -1,0 +1,10 @@
+using Volo.Abp;
+
+namespace FuseDigital.QuickSetup.VersionControlSystems;
+
+public class RepositoryAlreadyExistsException : AbpException
+{
+    public RepositoryAlreadyExistsException(string message) : base(message)
+    {
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
@@ -25,24 +25,44 @@ public class VersionControlDomainService : DomainService, IVersionControlDomainS
         Check.NotNullOrEmpty(relativePath, nameof(relativePath));
 
         var workingDirectory = _options.GetAbsolutePath(relativePath);
-        return RunGitCommand(new[] {"clone", sourceUrl, workingDirectory});
+        return RunGitCommand(new[] { "clone", sourceUrl, workingDirectory });
     }
 
     public IEnumerable<string> Init(string workingDirectory, IEnumerable<string> args = default)
     {
         Check.NotNullOrEmpty(workingDirectory, nameof(workingDirectory));
-        return RunGitCommand(new[] {"init", workingDirectory}, args);
+        return RunGitCommand(new[] { "init", workingDirectory }, args);
+    }
+
+    public IEnumerable<string> SetConfig(string key, string value, bool global = false)
+    {
+        Check.NotNullOrEmpty(key, nameof(key));
+        Check.NotNullOrEmpty(value, nameof(value));
+
+        var command = new List<string>()
+        {
+            "config"
+        };
+
+        if (global)
+        {
+            command.Add("--global");
+        }
+
+        command.AddRange(new[] { key, value });
+
+        return RunGitCommand(command);
     }
 
     public IEnumerable<string> Add(string pathSpec, IEnumerable<string> args = default)
     {
         Check.NotNullOrEmpty(pathSpec, nameof(pathSpec));
-        return RunGitCommand(new[] {"add", pathSpec}, args);
+        return RunGitCommand(new[] { "add", pathSpec }, args);
     }
 
     public IEnumerable<string> Status(IEnumerable<string> args = default)
     {
-        return RunGitCommand(new[] {"status"}, args);
+        return RunGitCommand(new[] { "status" }, args);
     }
 
     public IEnumerable<string> Commit(string message = default, IEnumerable<string> args = default)
@@ -50,25 +70,25 @@ public class VersionControlDomainService : DomainService, IVersionControlDomainS
         var commitMessage = string.IsNullOrEmpty(message)
             ? $"{DateTime.Now:yyyy.MM.dd_hh:mm:ss} from {Environment.UserName}@{Environment.MachineName}"
             : message;
-        return RunGitCommand(new[] {"commit", "-m", commitMessage}, args);
+        return RunGitCommand(new[] { "commit", "-m", commitMessage }, args);
     }
 
     public IEnumerable<string> RenameBranch(string name, IEnumerable<string> args = default)
     {
         Check.NotNullOrEmpty(name, nameof(name));
-        return RunGitCommand(new[] {"branch", "-M", name}, args);
+        return RunGitCommand(new[] { "branch", "-M", name }, args);
     }
 
     public IEnumerable<string> AddRemote(string remoteUrl, IEnumerable<string> args = default)
     {
         Check.NotNullOrEmpty(remoteUrl, nameof(remoteUrl));
-        return RunGitCommand(new[] {"remote", "add", "origin", remoteUrl}, args);
+        return RunGitCommand(new[] { "remote", "add", "origin", remoteUrl }, args);
     }
 
     public IEnumerable<string> PushSetUpstream(string branch, IEnumerable<string> args = default)
     {
         Check.NotNullOrEmpty(branch, nameof(branch));
-        return RunGitCommand(new[] {"push", "-u", "origin", branch}, args);
+        return RunGitCommand(new[] { "push", "-u", "origin", branch }, args);
     }
 
     private IEnumerable<string> RunGitCommand(IEnumerable<string> command, IEnumerable<string> args = default)

--- a/test/FuseDigital.QuickSetup.Domain.Tests/UserFiles/UserFileInitialiseTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/UserFiles/UserFileInitialiseTests.cs
@@ -1,0 +1,63 @@
+using System.IO;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.VersionControlSystems;
+using Shouldly;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+public class UserFileInitialiseTests : QuickSetupDomainTestBase
+{
+    [Fact]
+    public async Task Should_Initialise_When_No_Git_Folder_Exits()
+    {
+        // Arrange
+        const string defaultBranch = "trunk";
+        var remoteUrl = Settings.GetAbsolutePath($"~/server/dot-files.git");
+        Directory.CreateDirectory(Settings.UserProfile);
+        var versionControl = A.Fake<IVersionControlDomainService>();
+        A.CallTo(() => versionControl.RepositoryDirectory).Returns(".git");
+        var domainService = new UserFileDomainService(Options, versionControl);
+
+        // Act
+        await domainService.Initialise(remoteUrl, defaultBranch);
+
+        // Assert
+        A.CallTo(() => versionControl.Init(Settings.UserProfile, default)).MustHaveHappened();
+        A.CallTo(() => versionControl.Add(".", default)).MustHaveHappened();
+        A.CallTo(() => versionControl.Commit(default, default)).MustHaveHappened();
+        A.CallTo(() => versionControl.RenameBranch(defaultBranch, default)).MustHaveHappened();
+        A.CallTo(() => versionControl.AddRemote(remoteUrl, default)).MustHaveHappened();
+        A.CallTo(() => versionControl.PushSetUpstream(defaultBranch, default)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Not_Initialise_When_Git_Folder_Exits()
+    {
+        // Arrange
+        const string defaultBranch = "trunk";
+        var remoteUrl = Settings.GetAbsolutePath($"~/server/dot-files.fake");
+        Directory.CreateDirectory(Path.Combine(Settings.UserProfile, ".fake"));
+        var versionControl = A.Fake<IVersionControlDomainService>();
+        A.CallTo(() => versionControl.RepositoryDirectory).Returns(".fake");
+        var domainService = new UserFileDomainService(Options, versionControl);
+
+        // Act
+        var exception = await Should.ThrowAsync<RepositoryAlreadyExistsException>(async () =>
+        {
+            await domainService.Initialise(remoteUrl, defaultBranch);
+        });
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Message.ShouldBe(Settings.UserProfile);
+        
+        A.CallTo(() => versionControl.Init(Settings.UserProfile, default)).MustNotHaveHappened();
+        A.CallTo(() => versionControl.Add(".", default)).MustNotHaveHappened();
+        A.CallTo(() => versionControl.Commit(default, default)).MustNotHaveHappened();
+        A.CallTo(() => versionControl.RenameBranch(defaultBranch, default)).MustNotHaveHappened();
+        A.CallTo(() => versionControl.AddRemote(remoteUrl, default)).MustNotHaveHappened();
+        A.CallTo(() => versionControl.PushSetUpstream(defaultBranch, default)).MustNotHaveHappened();
+    }
+}

--- a/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
@@ -10,6 +10,7 @@ namespace FuseDigital.QuickSetup.VersionControlSystems;
 
 public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
 {
+
     private readonly VersionControlDomainService _versionControlSystem;
 
     public VersionControlSystemTests()
@@ -27,7 +28,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
         var relativePath = "~/projects/dot-files";
         var sourceUrl = Settings.GetAbsolutePath($"{relativePath}.git");
         var workingDirectory = Settings.GetAbsolutePath(relativePath);
-        _versionControlSystem.Init(sourceUrl, new[] {"--bare", "-b", "trunk"});
+        _versionControlSystem.Init(sourceUrl, new[] { "--bare", "-b", "trunk" });
 
         // Act
         _versionControlSystem.Clone(sourceUrl, relativePath);
@@ -42,10 +43,10 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
         // Arrange
         var relativePath = "~/projects/dot-files.git";
         var workingDirectory = Settings.GetAbsolutePath(relativePath);
-        
+
         // Act
         _versionControlSystem.Init(workingDirectory);
-        
+
         // Assert
         Directory.Exists(Path.Combine(workingDirectory, ".git")).ShouldBeTrue();
     }
@@ -60,44 +61,47 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
 
         const string filename = "README.md";
         await File.WriteAllTextAsync(Path.Combine(workingDirectory, filename), "# qup-empty-dotfiles");
-        
+
         // Act
         _versionControlSystem.WorkingDirectory = workingDirectory;
         _versionControlSystem.Add(filename);
-        
+
         // Assert
         _versionControlSystem
             .Status()
-            .Count(x => x.Contains("new file:", StringComparison.InvariantCultureIgnoreCase) && x.Contains(filename, StringComparison.InvariantCultureIgnoreCase))
+            .Count(x => x.Contains("new file:", StringComparison.InvariantCultureIgnoreCase)
+                        && x.Contains(filename, StringComparison.InvariantCultureIgnoreCase))
             .ShouldBe(1);
     }
-    
+
     [Fact]
     public async Task Commit_Should_Execute_From_With_In_The_Working_Directory()
     {
         // Arrange
         const string filename = "README.md";
         await Add_Should_Stage_Files_From_With_In_The_Working_Directory();
-        
+        _versionControlSystem.SetConfig("user.email", "john@doe.com");
+        _versionControlSystem.SetConfig("user.name", "john@doe.com");
+
         // Act
-        var output = _versionControlSystem.Commit("First commit");
-        
+        var output = _versionControlSystem.Commit("First commit").ToList();
+
         // Assert
         output
             .Count(x => x.Contains(filename, StringComparison.InvariantCultureIgnoreCase))
             .ShouldBe(1);
     }
-    
+
     [Fact]
     public async Task RenameBranch_Should_Execute_From_With_In_The_Working_Directory()
     {
         // Arrange
         const string name = "trunk";
         await Commit_Should_Execute_From_With_In_The_Working_Directory();
-        
+
         // Act
         _versionControlSystem.RenameBranch(name);
-        
+
         // Assert
         _versionControlSystem
             .Status()
@@ -111,7 +115,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
         // Arrange
         const string name = "trunk";
         var remoteUrl = Settings.GetAbsolutePath($"~/server/dot-files.git");
-        _versionControlSystem.Init(remoteUrl, new[] {"--bare", "-b", name});
+        _versionControlSystem.Init(remoteUrl, new[] { "--bare", "-b", name });
         await RenameBranch_Should_Execute_From_With_In_The_Working_Directory();
 
         // Act

--- a/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -67,7 +68,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
         // Assert
         _versionControlSystem
             .Status()
-            .Count(x => x.Contains("new file:") && x.Contains(filename))
+            .Count(x => x.Contains("new file:", StringComparison.InvariantCultureIgnoreCase) && x.Contains(filename, StringComparison.InvariantCultureIgnoreCase))
             .ShouldBe(1);
     }
     
@@ -83,7 +84,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
         
         // Assert
         output
-            .Count(x => x.Contains(filename))
+            .Count(x => x.Contains(filename, StringComparison.InvariantCultureIgnoreCase))
             .ShouldBe(1);
     }
     
@@ -100,7 +101,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
         // Assert
         _versionControlSystem
             .Status()
-            .Count(x => x.Contains($"On branch {name}"))
+            .Count(x => x.Contains($"On branch {name}", StringComparison.InvariantCultureIgnoreCase))
             .ShouldBe(1);
     }
 
@@ -119,7 +120,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
 
         // Assert
         output
-            .Count(x => x.Contains($"branch '{name}' set up to track 'origin/{name}'."))
+            .Count(x => x.Contains($"branch '{name}' set up to track", StringComparison.CurrentCultureIgnoreCase))
             .ShouldBe(1);
     }
 }

--- a/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
@@ -1,28 +1,125 @@
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Shouldly;
 using Volo.Abp.DependencyInjection;
 using Xunit;
 
 namespace FuseDigital.QuickSetup.VersionControlSystems;
 
-public class VersionControlSystemTests : QuickSetupDomainTestBase
+public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
 {
+    private readonly VersionControlDomainService _versionControlSystem;
+
+    public VersionControlSystemTests()
+    {
+        _versionControlSystem = new VersionControlDomainService(Options)
+        {
+            LazyServiceProvider = GetRequiredService<IAbpLazyServiceProvider>()
+        };
+    }
+
     [Fact]
-    public void Should_Clone_Project_In_Working_Directory()
+    public void Clone_Should_Create_Repository_In_Working_Directory()
     {
         // Arrange
-        var versionControlSystem = new VersionControlDomainService(Options)
-        {
-            LazyServiceProvider = GetService<IAbpLazyServiceProvider>()
-        };
-
         var relativePath = "~/projects/dot-files";
+        var sourceUrl = Settings.GetAbsolutePath($"{relativePath}.git");
         var workingDirectory = Settings.GetAbsolutePath(relativePath);
+        _versionControlSystem.Init(sourceUrl, new[] {"--bare", "-b", "trunk"});
 
         // Act
-        versionControlSystem.Clone("https://github.com/jesperorb/dotfiles.git", relativePath);
+        _versionControlSystem.Clone(sourceUrl, relativePath);
 
         // Assert
         Directory.Exists(workingDirectory).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Init_Should_Create_Repository_In_Working_Direcotry()
+    {
+        // Arrange
+        var relativePath = "~/projects/dot-files.git";
+        var workingDirectory = Settings.GetAbsolutePath(relativePath);
+        
+        // Act
+        _versionControlSystem.Init(workingDirectory);
+        
+        // Assert
+        Directory.Exists(Path.Combine(workingDirectory, ".git")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Add_Should_Stage_Files_From_With_In_The_Working_Directory()
+    {
+        // Arrange
+        var relativePath = "~/projects/dot-files";
+        var workingDirectory = Settings.GetAbsolutePath(relativePath);
+        _versionControlSystem.Init(workingDirectory);
+
+        const string filename = "README.md";
+        await File.WriteAllTextAsync(Path.Combine(workingDirectory, filename), "# qup-empty-dotfiles");
+        
+        // Act
+        _versionControlSystem.WorkingDirectory = workingDirectory;
+        _versionControlSystem.Add(filename);
+        
+        // Assert
+        _versionControlSystem
+            .Status()
+            .Count(x => x.Contains("new file:") && x.Contains(filename))
+            .ShouldBe(1);
+    }
+    
+    [Fact]
+    public async Task Commit_Should_Execute_From_With_In_The_Working_Directory()
+    {
+        // Arrange
+        const string filename = "README.md";
+        await Add_Should_Stage_Files_From_With_In_The_Working_Directory();
+        
+        // Act
+        var output = _versionControlSystem.Commit("First commit");
+        
+        // Assert
+        output
+            .Count(x => x.Contains(filename))
+            .ShouldBe(1);
+    }
+    
+    [Fact]
+    public async Task RenameBranch_Should_Execute_From_With_In_The_Working_Directory()
+    {
+        // Arrange
+        const string name = "trunk";
+        await Commit_Should_Execute_From_With_In_The_Working_Directory();
+        
+        // Act
+        _versionControlSystem.RenameBranch(name);
+        
+        // Assert
+        _versionControlSystem
+            .Status()
+            .Count(x => x.Contains($"On branch {name}"))
+            .ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task PushSetUpstream_Should_Execute_From_With_In_The_Working_Directory()
+    {
+        // Arrange
+        const string name = "trunk";
+        var remoteUrl = Settings.GetAbsolutePath($"~/server/dot-files.git");
+        _versionControlSystem.Init(remoteUrl, new[] {"--bare", "-b", name});
+        await RenameBranch_Should_Execute_From_With_In_The_Working_Directory();
+
+        // Act
+        _versionControlSystem.AddRemote(remoteUrl);
+        var output = _versionControlSystem.PushSetUpstream(name);
+
+        // Assert
+        output
+            .Count(x => x.Contains($"branch '{name}' set up to track 'origin/{name}'."))
+            .ShouldBe(1);
     }
 }

--- a/test/FuseDigital.QuickSetup.TestBase/QuickSetupTestBase.cs
+++ b/test/FuseDigital.QuickSetup.TestBase/QuickSetupTestBase.cs
@@ -31,9 +31,23 @@ public abstract class QuickSetupTestBase<TStartupModule> : AbpIntegratedTest<TSt
     {
         if (Directory.Exists(Settings.UserProfile))
         {
+            SetAttributes(new DirectoryInfo(Settings.UserProfile));
             Directory.Delete(Settings.UserProfile, true);
         }
 
         base.Dispose();
+    }
+
+    private void SetAttributes(DirectoryInfo directory)
+    {   
+        foreach (var subDirectory in directory.GetDirectories())
+        {
+            SetAttributes(subDirectory);
+        }
+
+        foreach (var file in directory.GetFiles())
+        {
+            file.Attributes = FileAttributes.Normal;
+        }
     }
 }


### PR DESCRIPTION

### Expand version control system commands

Expanded the implementation of commands for the version control system
to include Clone, Init, Add, Status, Commit, RenameBranch, AddRemote,
and PushSetUpstream.

### Implemented the `init` command

The init command initializes a new Git repository in the user profile
folder and pushes it to a remote repository. It also creates a
.gitignore and .gitinclude file to help manage file tracking and
synchronization.

### Update the `clone` command help

Updated the descriptions for the clone verb and options.

### Add debug directory isolation

Added isolation when the `FuseDigital.QuickSetup.Cli` project is
executed in debug mode.

Fixed an issue with files with a read-only attribute inside the .git
folder that throws an exception when a directory is recursively being
deleted. Recursively go through all files and change set their
attribute to `Normal`