### PR TITLE
Implement `checkout` command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,10 +2,6 @@ name: quick-setup-cd
 run-name: Publish pipeline after ${{github.event_name}} by @${{ github.actor }}
 
 on:
-  create:
-    branches:
-      - release/**
-
   push:
     branches:
       - release/**

--- a/src/FuseDigital.QuickSetup.Application/UserFiles/CheckoutCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/UserFiles/CheckoutCommand.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Volo.Abp.DependencyInjection;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+public class CheckoutCommand : UserFilesCommandAsync, ITransientDependency
+{
+    public CheckoutCommand(IOptions<QuickSetupOptions> options, IUserFileDomainService userFileServiceDomainService)
+        : base(options, userFileServiceDomainService)
+    {
+    }
+
+    public override async Task ExecuteAsync(IQupCommandOptions options)
+    {
+        var input = (CheckoutOptions)options;
+        if (UserFileService.Exists())
+        {
+            DisplayRepositoryExists();
+            return;
+        }
+
+        await UserFileService.CheckoutAsync(input.Repository, input.Branch);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/UserFiles/CheckoutOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/UserFiles/CheckoutOptions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using CommandLine;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+[Verb("checkout",HelpText = "Clones an existing QUP remote repository and checks out the specified branch as a local repository.")]
+public class CheckoutOptions : IQupCommandOptions
+{
+    [Value(0, Required = true, HelpText = "The URL of the remote repository to clone.")]
+    public string Repository { get; set; }
+    
+    [Value(1, Required = true, HelpText = "The name of the branch to check out.")]
+    public string Branch { get; set; }
+    
+    public Type GetCommandType()
+    {
+        return typeof(CheckoutCommand);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/UserFiles/InitialiseCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/UserFiles/InitialiseCommand.cs
@@ -1,34 +1,25 @@
-using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.DependencyInjection;
 
 namespace FuseDigital.QuickSetup.UserFiles;
 
-public class InitialiseCommand : QupCommandAsync, ITransientDependency
+public class InitialiseCommand : UserFilesCommandAsync, ITransientDependency
 {
-    private readonly IUserFileDomainService _userFileDomainService;
-    private readonly QuickSetupOptions _options;
-
-    public InitialiseCommand(IUserFileDomainService userFileDomainService, IOptions<QuickSetupOptions> options)
+    public InitialiseCommand(IOptions<QuickSetupOptions> options, IUserFileDomainService userFileServiceDomainService) 
+        : base(options, userFileServiceDomainService)
     {
-        _userFileDomainService = userFileDomainService;
-        _options = options.Value;
     }
 
     public override async Task ExecuteAsync(IQupCommandOptions options)
     {
-        var init = (InitialiseOptions) options;
-
-        if (_userFileDomainService.Exists())
+        var init = (InitialiseOptions)options;
+        if (UserFileService.Exists())
         {
-            const string message = "A source repository already exists in {0}";
-            Logger.LogInformation(message, _options.UserProfile);
-            Console.WriteLine(message, _options.UserProfile);
+            DisplayRepositoryExists();
             return;
         }
 
-        await _userFileDomainService.Initialise(init.Repository, init.DefaultBranchName);
+        await UserFileService.InitialiseAsync(init.Repository, init.DefaultBranchName);
     }
 }

--- a/src/FuseDigital.QuickSetup.Application/UserFiles/InitialiseOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/UserFiles/InitialiseOptions.cs
@@ -6,7 +6,7 @@ namespace FuseDigital.QuickSetup.UserFiles;
 [Verb("init", HelpText = "Initializes a new local git repository and pushes it to a remote repository.")]
 public class InitialiseOptions : IQupCommandOptions
 {
-    [Value(0, Required = true, HelpText = "he URL of the empty remote repository.")]
+    [Value(0, Required = true, HelpText = "The URL of the empty remote repository.")]
     public string Repository { get; set; }
     
     [Value(1, Required = true, HelpText = "The name of the default branch for the repository.")]

--- a/src/FuseDigital.QuickSetup.Application/UserFiles/UserFilesCommandAsync.cs
+++ b/src/FuseDigital.QuickSetup.Application/UserFiles/UserFilesCommandAsync.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+public abstract class UserFilesCommandAsync : QupCommandAsync
+{
+    private QuickSetupOptions Settings { get; }
+    protected IUserFileDomainService UserFileService { get; }
+
+    protected UserFilesCommandAsync(IOptions<QuickSetupOptions> options, IUserFileDomainService userFileServiceDomainService)
+    {
+        Settings = options.Value;
+        UserFileService = userFileServiceDomainService;
+    }
+
+    protected void DisplayRepositoryExists()
+    {
+        const string message = "A local repository already exists in {0}";
+        Logger.LogInformation(message, Settings.UserProfile);
+        Console.WriteLine(message, Settings.UserProfile);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/UserFiles/IUserFileDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/UserFiles/IUserFileDomainService.cs
@@ -6,5 +6,5 @@ public interface IUserFileDomainService : IDomainService
 {
     bool Exists();
 
-    Task Initialise(string sourceUrl, string defaultBranch);
+    Task InitialiseAsync(string sourceUrl, string defaultBranch);
 }

--- a/src/FuseDigital.QuickSetup.Domain/UserFiles/IUserFileDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/UserFiles/IUserFileDomainService.cs
@@ -7,4 +7,6 @@ public interface IUserFileDomainService : IDomainService
     bool Exists();
 
     Task InitialiseAsync(string sourceUrl, string defaultBranch);
+
+    Task CheckoutAsync(string sourceUrl, string branch);
 }

--- a/src/FuseDigital.QuickSetup.Domain/UserFiles/UserFileDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/UserFiles/UserFileDomainService.cs
@@ -23,10 +23,11 @@ public class UserFileDomainService : DomainService, IUserFileDomainService
         return Directory.Exists(path);
     }
 
-    public async Task Initialise(string sourceUrl, string defaultBranch)
+    public async Task InitialiseAsync(string sourceUrl, string defaultBranch)
     {
         Check.NotNull(sourceUrl, nameof(sourceUrl));
         Check.NotNull(defaultBranch, nameof(defaultBranch));
+
         if (Exists())
         {
             throw new RepositoryAlreadyExistsException(_options.UserProfile);

--- a/src/FuseDigital.QuickSetup.Domain/UserFiles/UserFileDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/UserFiles/UserFileDomainService.cs
@@ -43,6 +43,24 @@ public class UserFileDomainService : DomainService, IUserFileDomainService
         _versionControl.PushSetUpstream(defaultBranch);
     }
 
+    public Task CheckoutAsync(string sourceUrl, string branch)
+    {
+        Check.NotNull(sourceUrl, nameof(sourceUrl));
+        Check.NotNull(branch, nameof(branch));
+
+        if (Exists())
+        {
+            throw new RepositoryAlreadyExistsException(_options.UserProfile);
+        }
+
+        _versionControl.Init(_options.UserProfile);
+        _versionControl.AddRemote(sourceUrl);
+        _versionControl.Fetch();
+        _versionControl.Checkout(branch);
+
+        return Task.CompletedTask;
+    }
+
     private async Task CreateIgnoreFile()
     {
         var ignore = new[]

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
@@ -10,7 +10,9 @@ public interface IVersionControlDomainService : IDomainService
 
     IEnumerable<string> Clone(string sourceUrl, string relativePath);
 
-    IEnumerable<string> Init(string workingDirectory, IEnumerable<string> args = default);
+    IEnumerable<string> Init(string workingDirectory, 
+        IEnumerable<string> args = default,
+        bool changeWorkingDirectory = false);
 
     IEnumerable<string> Add(string pathSpec, IEnumerable<string> args = default);
 

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
@@ -5,7 +5,7 @@ namespace FuseDigital.QuickSetup.VersionControlSystems;
 public interface IVersionControlDomainService : IDomainService
 {
     string WorkingDirectory { get; set; }
-    
+
     string RepositoryDirectory { get; }
 
     IEnumerable<string> Clone(string sourceUrl, string relativePath);
@@ -27,4 +27,8 @@ public interface IVersionControlDomainService : IDomainService
     IEnumerable<string> AddRemote(string remoteUrl, IEnumerable<string> args = default);
 
     IEnumerable<string> PushSetUpstream(string branch, IEnumerable<string> args = default);
+
+    IEnumerable<string> Fetch(IEnumerable<string> args = default);
+
+    IEnumerable<string> Checkout(string branch, IEnumerable<string> args = default);
 }

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
@@ -28,10 +28,19 @@ public class VersionControlDomainService : DomainService, IVersionControlDomainS
         return RunGitCommand(new[] { "clone", sourceUrl, workingDirectory });
     }
 
-    public IEnumerable<string> Init(string workingDirectory, IEnumerable<string> args = default)
+    public IEnumerable<string> Init(string workingDirectory, 
+        IEnumerable<string> args = default,
+        bool changeWorkingDirectory = false)
     {
         Check.NotNullOrEmpty(workingDirectory, nameof(workingDirectory));
-        return RunGitCommand(new[] { "init", workingDirectory }, args);
+        var output = RunGitCommand(new[] { "init", workingDirectory }, args);
+
+        if (changeWorkingDirectory)
+        {
+            WorkingDirectory = workingDirectory;
+        }
+
+        return output;
     }
 
     public IEnumerable<string> SetConfig(string key, string value, bool global = false)

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
@@ -100,6 +100,17 @@ public class VersionControlDomainService : DomainService, IVersionControlDomainS
         return RunGitCommand(new[] { "push", "-u", "origin", branch }, args);
     }
 
+    public IEnumerable<string> Fetch(IEnumerable<string> args = default)
+    {
+        return RunGitCommand(new[] { "fetch", "--prune" }, args);
+    }
+
+    public IEnumerable<string> Checkout(string branch, IEnumerable<string> args = default)
+    {
+        Check.NotNullOrEmpty(branch, nameof(branch));
+        return RunGitCommand(new[] { "checkout", "-t", $"origin/{branch}", "-f" });
+    }
+
     private IEnumerable<string> RunGitCommand(IEnumerable<string> command, IEnumerable<string> args = default)
     {
         var arguments = command.Concat(args ?? new List<string>());
@@ -110,7 +121,7 @@ public class VersionControlDomainService : DomainService, IVersionControlDomainS
         var output = process?.StandardOutput.ReadToEnd();
         process?.WaitForExit();
 
-        return output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        return output?.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
     }
 
     private ProcessStartInfo GitCommand(IEnumerable<string> args)

--- a/test/FuseDigital.QuickSetup.Application.Tests/UserFiles/CheckoutCommandTests.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/UserFiles/CheckoutCommandTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Threading.Tasks;
+using FakeItEasy;
+using Volo.Abp.DependencyInjection;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+public class CheckoutCommandTests : QuickSetupApplicationTestBase
+{
+    [Fact]
+    public async Task Should_Not_Checkout_If_Repository_Already_Exists()
+    {
+        // Arrange
+        var domainService = A.Fake<IUserFileDomainService>();
+        A.CallTo(() => domainService.Exists()).Returns(true);
+
+        var command = GetCheckoutCommand(domainService);
+        var options = GetCheckoutOptions();
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Assert
+        A.CallTo(() => domainService.CheckoutAsync(options.Repository, options.Branch))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Checkout_If_Repository_Does_Not_Exists()
+    {
+        // Arrange
+        var domainService = A.Fake<IUserFileDomainService>();
+        A.CallTo(() => domainService.Exists()).Returns(false);
+
+        var command = GetCheckoutCommand(domainService);
+        var options = GetCheckoutOptions();
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Assert
+        A.CallTo(() => domainService.CheckoutAsync(options.Repository, options.Branch))
+            .MustHaveHappened();
+    }
+
+    private CheckoutOptions GetCheckoutOptions()
+    {
+        return new CheckoutOptions
+        {
+            Repository = "git@github.com:user/project.git",
+            Branch = "master"
+        };
+    }
+
+    private CheckoutCommand GetCheckoutCommand(IUserFileDomainService domainService)
+    {
+        return new CheckoutCommand(Options, domainService)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+    }
+}

--- a/test/FuseDigital.QuickSetup.Application.Tests/UserFiles/InitialiseCommandTests.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/UserFiles/InitialiseCommandTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Threading.Tasks;
+using FakeItEasy;
+using Volo.Abp.DependencyInjection;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+public class InitialiseCommandTests : QuickSetupApplicationTestBase
+{
+    [Fact]
+    public async Task Should_Not_Initialise_If_Repository_Already_Exists()
+    {
+        // Arrange
+        var domainService = A.Fake<IUserFileDomainService>();
+        A.CallTo(() => domainService.Exists()).Returns(true);
+
+        var command = GetInitialiseCommand(domainService);
+        var options = GetInitialiseOptions();
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Assert
+        A.CallTo(() => domainService.InitialiseAsync(options.Repository, options.DefaultBranchName))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Initialise_If_Repository_Does_Not_Exists()
+    {
+        // Arrange
+        var domainService = A.Fake<IUserFileDomainService>();
+        A.CallTo(() => domainService.Exists()).Returns(false);
+
+        var command = GetInitialiseCommand(domainService);
+        var options = GetInitialiseOptions();
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Assert
+        A.CallTo(() => domainService.InitialiseAsync(options.Repository, options.DefaultBranchName))
+            .MustHaveHappened();
+    }
+
+    private InitialiseOptions GetInitialiseOptions()
+    {
+        return new InitialiseOptions
+        {
+            Repository = "git@github.com:user/project.git",
+            DefaultBranchName = "master",
+        };
+    }
+
+    private InitialiseCommand GetInitialiseCommand(IUserFileDomainService domainService)
+    {
+        return new InitialiseCommand(Options, domainService)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+    }
+}

--- a/test/FuseDigital.QuickSetup.Domain.Tests/UserFiles/UserFileCheckoutTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/UserFiles/UserFileCheckoutTests.cs
@@ -1,0 +1,59 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.VersionControlSystems;
+using Shouldly;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.UserFiles;
+
+public class UserFileCheckoutTests : QuickSetupDomainTestBase
+{
+    [Fact]
+    public async Task Should_Checkout_When_No_Git_Folder_Exits()
+    {
+        // Arrange
+        const string branch = "trunk";
+        var remoteUrl = Settings.GetAbsolutePath($"~/server/dot-files.git");
+        Directory.CreateDirectory(Settings.UserProfile);
+        var versionControl = A.Fake<IVersionControlDomainService>();
+        A.CallTo(() => versionControl.RepositoryDirectory).Returns(".git");
+        var domainService = new UserFileDomainService(Options, versionControl);
+
+        // Act
+        await domainService.CheckoutAsync(remoteUrl, branch);
+
+        // Assert
+        A.CallTo(() => versionControl.Init(Settings.UserProfile, default, default)).MustHaveHappened();
+        A.CallTo(() => versionControl.AddRemote(remoteUrl, default)).MustHaveHappened();
+        A.CallTo(() => versionControl.Fetch(default)).MustHaveHappened();
+        A.CallTo(() => versionControl.Checkout(branch, default)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Not_Checkout_When_Git_Folder_Exits()
+    {
+        // Arrange
+        const string branch = "trunk";
+        var remoteUrl = Settings.GetAbsolutePath($"~/server/dot-files.fake");
+        Directory.CreateDirectory(Path.Combine(Settings.UserProfile, ".fake"));
+        var versionControl = A.Fake<IVersionControlDomainService>();
+        A.CallTo(() => versionControl.RepositoryDirectory).Returns(".fake");
+        var domainService = new UserFileDomainService(Options, versionControl);
+
+        // Act
+        var exception = await Should.ThrowAsync<RepositoryAlreadyExistsException>(async () =>
+        {
+            await domainService.CheckoutAsync(remoteUrl, branch);
+        });
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Message.ShouldBe(Settings.UserProfile);
+        
+        A.CallTo(() => versionControl.Init(Settings.UserProfile, default, default)).MustNotHaveHappened();
+        A.CallTo(() => versionControl.AddRemote(remoteUrl, default)).MustNotHaveHappened();
+        A.CallTo(() => versionControl.Fetch(default)).MustNotHaveHappened();
+        A.CallTo(() => versionControl.Checkout(branch, default)).MustNotHaveHappened();
+    }
+}

--- a/test/FuseDigital.QuickSetup.Domain.Tests/UserFiles/UserFileInitialiseTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/UserFiles/UserFileInitialiseTests.cs
@@ -21,10 +21,10 @@ public class UserFileInitialiseTests : QuickSetupDomainTestBase
         var domainService = new UserFileDomainService(Options, versionControl);
 
         // Act
-        await domainService.Initialise(remoteUrl, defaultBranch);
+        await domainService.InitialiseAsync(remoteUrl, defaultBranch);
 
         // Assert
-        A.CallTo(() => versionControl.Init(Settings.UserProfile, default)).MustHaveHappened();
+        A.CallTo(() => versionControl.Init(Settings.UserProfile, default, default)).MustHaveHappened();
         A.CallTo(() => versionControl.Add(".", default)).MustHaveHappened();
         A.CallTo(() => versionControl.Commit(default, default)).MustHaveHappened();
         A.CallTo(() => versionControl.RenameBranch(defaultBranch, default)).MustHaveHappened();
@@ -46,14 +46,14 @@ public class UserFileInitialiseTests : QuickSetupDomainTestBase
         // Act
         var exception = await Should.ThrowAsync<RepositoryAlreadyExistsException>(async () =>
         {
-            await domainService.Initialise(remoteUrl, defaultBranch);
+            await domainService.InitialiseAsync(remoteUrl, defaultBranch);
         });
 
         // Assert
         exception.ShouldNotBeNull();
         exception.Message.ShouldBe(Settings.UserProfile);
         
-        A.CallTo(() => versionControl.Init(Settings.UserProfile, default)).MustNotHaveHappened();
+        A.CallTo(() => versionControl.Init(Settings.UserProfile, default, default)).MustNotHaveHappened();
         A.CallTo(() => versionControl.Add(".", default)).MustNotHaveHappened();
         A.CallTo(() => versionControl.Commit(default, default)).MustNotHaveHappened();
         A.CallTo(() => versionControl.RenameBranch(defaultBranch, default)).MustNotHaveHappened();

--- a/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
@@ -10,8 +10,13 @@ namespace FuseDigital.QuickSetup.VersionControlSystems;
 
 public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
 {
-
     private readonly VersionControlDomainService _versionControlSystem;
+    private const string RepoRelativePath = "~/projects/dot-files";
+    private const string Filename = "README.md";
+    private const string BranchName = "trunk";
+    private string RepoWorkingDirectory { get; }
+    private string SecondRepoWorkingDirectory { get; }
+    private string RemoteUrl { get; }
 
     public VersionControlSystemTests()
     {
@@ -19,58 +24,78 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
         {
             LazyServiceProvider = GetRequiredService<IAbpLazyServiceProvider>()
         };
+        RepoWorkingDirectory = Settings.GetAbsolutePath(RepoRelativePath);
+        SecondRepoWorkingDirectory = Settings.GetAbsolutePath("~/projects/dot-files-second");
+        RemoteUrl = Settings.GetAbsolutePath($"~/server/dot-files.git");
     }
 
     [Fact]
     public void Clone_Should_Create_Repository_In_Working_Directory()
     {
         // Arrange
-        var relativePath = "~/projects/dot-files";
-        var sourceUrl = Settings.GetAbsolutePath($"{relativePath}.git");
-        var workingDirectory = Settings.GetAbsolutePath(relativePath);
-        _versionControlSystem.Init(sourceUrl, new[] { "--bare", "-b", "trunk" });
+        _versionControlSystem.Init(RemoteUrl, new[] { "--bare", "-b", BranchName });
 
         // Act
-        _versionControlSystem.Clone(sourceUrl, relativePath);
+        _versionControlSystem.Clone(RemoteUrl, RepoRelativePath);
 
         // Assert
-        Directory.Exists(workingDirectory).ShouldBeTrue();
+        Directory.Exists(RepoWorkingDirectory).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Fetch_Should_Retrieve_Metadata_From_Remote_Repository()
+    {
+        // Arrange
+        await PushSetUpstream_Should_Execute_From_With_In_The_Working_Directory();
+        _versionControlSystem.Init(SecondRepoWorkingDirectory, changeWorkingDirectory: true);
+        _versionControlSystem.AddRemote(RemoteUrl);
+
+        // Act
+        _versionControlSystem.Fetch();
+
+        // Assert
+        Directory.Exists(SecondRepoWorkingDirectory).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Checkout_Should_Retrieve_Files_From_Remote_Repository()
+    {
+        // Arrange
+        await Fetch_Should_Retrieve_Metadata_From_Remote_Repository();
+
+        // Act
+        _versionControlSystem.Checkout(BranchName);
+
+        // Assert
+        File.Exists(Path.Combine(SecondRepoWorkingDirectory, Filename)).ShouldBeTrue();
     }
 
     [Fact]
     public void Init_Should_Create_Repository_In_Working_Direcotry()
     {
-        // Arrange
-        var relativePath = "~/projects/dot-files.git";
-        var workingDirectory = Settings.GetAbsolutePath(relativePath);
-
         // Act
-        _versionControlSystem.Init(workingDirectory);
+        _versionControlSystem.Init(RepoWorkingDirectory);
 
         // Assert
-        Directory.Exists(Path.Combine(workingDirectory, ".git")).ShouldBeTrue();
+        Directory.Exists(Path.Combine(RepoWorkingDirectory, ".git")).ShouldBeTrue();
     }
 
     [Fact]
     public async Task Add_Should_Stage_Files_From_With_In_The_Working_Directory()
     {
         // Arrange
-        var relativePath = "~/projects/dot-files";
-        var workingDirectory = Settings.GetAbsolutePath(relativePath);
-        _versionControlSystem.Init(workingDirectory);
-
-        const string filename = "README.md";
-        await File.WriteAllTextAsync(Path.Combine(workingDirectory, filename), "# qup-empty-dotfiles");
+        _versionControlSystem.Init(RepoWorkingDirectory, changeWorkingDirectory: true);
+        await File.WriteAllTextAsync(Path.Combine(RepoWorkingDirectory, Filename), "# qup-empty-dotfiles");
 
         // Act
-        _versionControlSystem.WorkingDirectory = workingDirectory;
-        _versionControlSystem.Add(filename);
+        _versionControlSystem.Add(Filename);
 
         // Assert
         _versionControlSystem
             .Status()
-            .Count(x => x.Contains("new file:", StringComparison.InvariantCultureIgnoreCase)
-                        && x.Contains(filename, StringComparison.InvariantCultureIgnoreCase))
+            .Count(x =>
+                x.Contains("new file:", StringComparison.InvariantCultureIgnoreCase)
+                && x.Contains(Filename, StringComparison.InvariantCultureIgnoreCase))
             .ShouldBe(1);
     }
 
@@ -78,7 +103,6 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
     public async Task Commit_Should_Execute_From_With_In_The_Working_Directory()
     {
         // Arrange
-        const string filename = "README.md";
         await Add_Should_Stage_Files_From_With_In_The_Working_Directory();
         _versionControlSystem.SetConfig("user.email", "john@doe.com");
         _versionControlSystem.SetConfig("user.name", "john@doe.com");
@@ -88,7 +112,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
 
         // Assert
         output
-            .Count(x => x.Contains(filename, StringComparison.InvariantCultureIgnoreCase))
+            .Count(x => x.Contains(Filename, StringComparison.InvariantCultureIgnoreCase))
             .ShouldBe(1);
     }
 
@@ -96,16 +120,15 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
     public async Task RenameBranch_Should_Execute_From_With_In_The_Working_Directory()
     {
         // Arrange
-        const string name = "trunk";
         await Commit_Should_Execute_From_With_In_The_Working_Directory();
 
         // Act
-        _versionControlSystem.RenameBranch(name);
+        _versionControlSystem.RenameBranch(BranchName);
 
         // Assert
         _versionControlSystem
             .Status()
-            .Count(x => x.Contains($"On branch {name}", StringComparison.InvariantCultureIgnoreCase))
+            .Count(x => x.Contains($"On branch {BranchName}", StringComparison.InvariantCultureIgnoreCase))
             .ShouldBe(1);
     }
 
@@ -113,18 +136,16 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
     public async Task PushSetUpstream_Should_Execute_From_With_In_The_Working_Directory()
     {
         // Arrange
-        const string name = "trunk";
-        var remoteUrl = Settings.GetAbsolutePath($"~/server/dot-files.git");
-        _versionControlSystem.Init(remoteUrl, new[] { "--bare", "-b", name });
+        _versionControlSystem.Init(RemoteUrl, new[] { "--bare", "-b", BranchName });
         await RenameBranch_Should_Execute_From_With_In_The_Working_Directory();
 
         // Act
-        _versionControlSystem.AddRemote(remoteUrl);
-        var output = _versionControlSystem.PushSetUpstream(name);
+        _versionControlSystem.AddRemote(RemoteUrl);
+        var output = _versionControlSystem.PushSetUpstream(BranchName);
 
         // Assert
         output
-            .Count(x => x.Contains($"branch '{name}' set up to track", StringComparison.CurrentCultureIgnoreCase))
+            .Count(x => x.Contains($"branch '{BranchName}' set up to track", StringComparison.CurrentCultureIgnoreCase))
             .ShouldBe(1);
     }
 }


### PR DESCRIPTION

### Fix publish workflow

Removed the trigger on branch create as this caused the workflow to be
executed when a branch is created and again when changes are pushed to
the branch.

### Refactor `init` command

Extracted an abstract class called UserFilesCommandAsync that can be
reused by other commands, reducing the code required when new codes are
added.

Added additional tests for the application layer and refactored some of
the domain layer tests.

### Add `fetch` and `checkout` to version control

Added the `fetch` and `checkout` commands to version control domain
service. Refactor the unit test to reuse const and private properties
to reduce the code for each test.

### Implement `checkout` command

The checkout command allows users to clone an existing QUP remote
repository and check out a specific branch as a local repository.

This commit includes the implementation of the checkout command and
related functionality, as well as documentation and testing.