### PR TITLE
Fix UserFileRepository exceptions

### DIFF
--- a/src/FuseDigital.QuickSetup.Infrastructure/Repositories/UserFileRepository.cs
+++ b/src/FuseDigital.QuickSetup.Infrastructure/Repositories/UserFileRepository.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using FuseDigital.QuickSetup.Text;
 using FuseDigital.QuickSetup.UserFiles;
 
@@ -5,6 +6,10 @@ namespace FuseDigital.QuickSetup.Repositories;
 
 public class UserFileRepository : TextRepository, IUserFileRepository
 {
+    public override string FileName => ".gitinclude";
+
+    public override string FilePath => Path.Combine(Context.Options.UserProfile, FileName);
+
     public UserFileRepository(ITextContext context) : base(context)
     {
     }


### PR DESCRIPTION

Fixed the exceptions been thrown by the `FindAsync` on the `UserFileRepository` because the FileName property has not been set.

Changed the `TextRepository` to be an abstract class with an abstract property for the `FileName`, which ensures that the property gets set at compile time.