### PR TITLE
Make `TextRepository` an abstract class

### DIFF
--- a/src/FuseDigital.QuickSetup.Infrastructure/Text/TextRepository.cs
+++ b/src/FuseDigital.QuickSetup.Infrastructure/Text/TextRepository.cs
@@ -10,9 +10,9 @@ using Volo.Abp.Domain.Entities;
 
 namespace FuseDigital.QuickSetup.Text;
 
-public class TextRepository : ITextRepository
+public abstract class TextRepository : ITextRepository
 {
-    public virtual string FileName { get; }
+    public abstract string FileName { get; }
 
     public virtual string FilePath => Path.Combine(Context.Options.UserProfile, Context.Options.BaseDirectory, FileName);
 


### PR DESCRIPTION
Changed the TextRepository to be an abstract class with an abstract property for the FileName, which ensures that the property gets set at compile time.