### PR TITLE
Implement the `install` command

### DIFF
--- a/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/InstallOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/InstallOptions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using CommandLine;
+
+namespace FuseDigital.QuickSetup.PackageManagers.Dto;
+
+[Verb("install", HelpText = "install stuff")]
+public class InstallOptions : IQupCommandOptions
+{
+    [Value(1, MetaName = "package-manager", Required = false, HelpText = "")]
+    public string PackageManager { get; set; }
+
+    [Value(1, MetaName = "package", Required = false, HelpText = "")]
+    public IEnumerable<string> Package { get; set; }
+
+    public Type GetCommandType()
+    {
+        return typeof(InstallCommand);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/PackageManagers/InstallCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/PackageManagers/InstallCommand.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FuseDigital.QuickSetup.PackageManagers.Dto;
+using FuseDigital.QuickSetup.Platforms;
+using Volo.Abp.DependencyInjection;
+
+namespace FuseDigital.QuickSetup.PackageManagers;
+
+public class InstallCommand : QupCommandAsync, ITransientDependency
+{
+    private readonly IPackageManagerRepository _repository;
+    private readonly IShellDomainService _shell;
+    private readonly PlatformOperatingSystem _currentOperatingSystem;
+
+    public InstallCommand(IPackageManagerRepository repository, IShellDomainService shell)
+    {
+        _repository = repository;
+        _shell = shell;
+        _currentOperatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+    }
+
+    public override async Task ExecuteAsync(IQupCommandOptions options)
+    {
+        var installOptions = (InstallOptions) options;
+        var packageManager = installOptions.PackageManager;
+        var package = (installOptions.Package ?? Array.Empty<string>())
+            .JoinAsString(" ");
+
+        if (string.IsNullOrEmpty(packageManager))
+        {
+            await InstallAsync();
+        }
+        else if (string.IsNullOrEmpty(package))
+        {
+            await InstallPackageManagerAsync(packageManager);
+        }
+        else
+        {
+            await InstallPackage(packageManager, package);
+        }
+    }
+
+    private async Task InstallAsync()
+    {
+        var packageManagers = await _repository
+            .GetListAsync(x => x.RunsOn.Contains(_currentOperatingSystem));
+
+        foreach (var packageManager in packageManagers)
+        {
+            await packageManager.InstallPackagesAsync(_shell);
+        }
+    }
+
+    private async Task InstallPackageManagerAsync(string name)
+    {
+        var packageManager = await _repository.GetAsync(name);
+        await packageManager.InstallPackagesAsync(_shell);
+    }
+
+    private async Task InstallPackage(string name, string package)
+    {
+        var packageManager = await _repository.GetAsync(name);
+        await packageManager.AddPackageAsync(package, _shell);
+        await _repository.UpdateAsync(packageManager);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/PackageManagers/IPackageManagerRepository.cs
+++ b/src/FuseDigital.QuickSetup.Domain/PackageManagers/IPackageManagerRepository.cs
@@ -1,0 +1,8 @@
+using Volo.Abp.Domain.Repositories;
+
+namespace FuseDigital.QuickSetup.PackageManagers;
+
+public interface IPackageManagerRepository : IRepository<PackageManager>
+{
+    Task<PackageManager> GetAsync(string name);
+}

--- a/src/FuseDigital.QuickSetup.Domain/PackageManagers/PackageManager.cs
+++ b/src/FuseDigital.QuickSetup.Domain/PackageManagers/PackageManager.cs
@@ -1,0 +1,88 @@
+using System.ComponentModel.DataAnnotations;
+using FuseDigital.QuickSetup.Platforms;
+using Volo.Abp;
+using Volo.Abp.Domain.Entities;
+
+namespace FuseDigital.QuickSetup.PackageManagers;
+
+public class PackageManager : Entity
+{
+    [Display(Description = "The name of the package manager")]
+    [Required]
+    [RegularExpression(@"^[a-zA-Z0-9_-]+$")]
+    public string Name { get; set; }
+
+    [Display(Description = "The package manager supported operating systems.")]
+    public IList<PlatformOperatingSystem> RunsOn { get; set; } = new List<PlatformOperatingSystem>();
+
+    [Display(Description = "The description of the package manager")]
+    public string Description { get; set; }
+
+    [Display(Description = "The pre-install commands that needs to be executed for the package manager")]
+    public string PreInstall { get; set; }
+
+    [Display(Description = "The commands that needs to be executed for the package manager to install a packages")]
+    [Required]
+    public string Install { get; set; }
+
+    [Display(Description = "Update all the packages that have been installed by the package manager")]
+    public string Update { get; set; }
+
+    [Display(Description = "The post install commands that needs to be executed for the package manager")]
+    public string PostInstall { get; set; }
+
+    [Display(Description = "The list of packages that are being maintained by the package manager")]
+    public IList<string> Packages { get; set; } = new List<string>();
+
+    public override object[] GetKeys()
+    {
+        return new object[] {Name};
+    }
+
+    public async Task InstallPackagesAsync(IShellDomainService shell)
+    {
+        var operatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+        if (!RunsOn.Contains(operatingSystem))
+        {
+            throw new BusinessException("PM-001",
+                $"{Name} package manager is not configured to run on {operatingSystem}");
+        }
+
+        if (string.IsNullOrEmpty(Install))
+        {
+            throw new BusinessException("PM-002",
+                $"No install settings specified for the {Name} package manager");
+        }
+
+        if (!string.IsNullOrEmpty(PreInstall))
+        {
+            await shell.RunProcessAsync(PreInstall);
+        }
+
+        foreach (var package in Packages ?? new List<string>())
+        {
+            await shell.RunProcessAsync(Install, package);
+        }
+
+        if (!string.IsNullOrEmpty(PostInstall))
+        {
+            await shell.RunProcessAsync(PostInstall);
+        }
+    }
+
+    public async Task AddPackageAsync(string package, IShellDomainService shell)
+    {
+        if (Packages.Contains(package, StringComparer.InvariantCultureIgnoreCase))
+        {
+            throw new BusinessException("PM-003", $"Package {package} is already installed");
+        }
+
+        var result = await shell.RunProcessAsync(Install, package);
+
+        if (result.ExitCode == 0)
+        {
+            Packages.Add(package);
+            Packages = Packages.OrderBy(x => x).ToList();
+        }
+    }
+}

--- a/src/FuseDigital.QuickSetup.Infrastructure/Repositories/PackageManagerRepository.cs
+++ b/src/FuseDigital.QuickSetup.Infrastructure/Repositories/PackageManagerRepository.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using FuseDigital.QuickSetup.PackageManagers;
+using FuseDigital.QuickSetup.Yaml;
+using Volo.Abp.Domain.Entities;
+
+namespace FuseDigital.QuickSetup.Repositories;
+
+public class PackageManagerRepository : YamlRepository<PackageManager>, IPackageManagerRepository
+{
+    public override string FileName => "packages.yml";
+
+    public PackageManagerRepository(IYamlContext context) : base(context)
+    {
+    }
+
+    public async Task<PackageManager> GetAsync(string name)
+    {
+        var packageManager = await FindAsync(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+        if (packageManager == null)
+        {
+            throw new EntityNotFoundException($"No {name} package manager configured");
+        }
+
+        return packageManager;
+    }
+}

--- a/test/FuseDigital.QuickSetup.Application.Tests/FuseDigital.QuickSetup.Application.Tests.csproj
+++ b/test/FuseDigital.QuickSetup.Application.Tests/FuseDigital.QuickSetup.Application.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <EmbeddedResource Include="PackageManagers\packages.yml" />
     <EmbeddedResource Include="Projects\project-exists.yml" />
   </ItemGroup>
 

--- a/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/InstallCommandTests.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/InstallCommandTests.cs
@@ -1,0 +1,237 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.PackageManagers.Dto;
+using FuseDigital.QuickSetup.Platforms;
+using FuseDigital.QuickSetup.Platforms.Dto;
+using FuseDigital.QuickSetup.Repositories;
+using FuseDigital.QuickSetup.Yaml;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Entities;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.PackageManagers;
+
+public class InstallCommandTests : QuickSetupApplicationTestBase
+{
+    [Fact]
+    public async Task Should_Install_Packages_For_All_Package_Managers()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new PackageManagerRepository(context);
+        await CopyFileAsync("packages.yml", repository.FilePath);
+
+        var options = new InstallOptions();
+        var command = new InstallCommand(repository, shell)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync("package-manager-1 update"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 install -y", "package01-01"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 install -y", "package01-02"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 --prune"))
+            .MustHaveHappened();
+
+        A.CallTo(() => shell.RunProcessAsync("package-manager-2 update"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager2 install -y", "package02-01"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager2 install -y", "package02-02"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager2 --prune"))
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Install_Packages_Only_For_Specified_Package_Manager()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new PackageManagerRepository(context);
+        await CopyFileAsync("packages.yml", repository.FilePath);
+
+        var options = new InstallOptions
+        {
+            PackageManager = "package-manager-1"
+        };
+
+        var command = new InstallCommand(repository, shell)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync("package-manager-1 update"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 install -y", "package01-01"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 install -y", "package01-02"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 --prune"))
+            .MustHaveHappened();
+
+        A.CallTo(() => shell.RunProcessAsync("package-manager-2 update"))
+            .MustNotHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager2 install -y", "package02-01"))
+            .MustNotHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager2 install -y", "package02-02"))
+            .MustNotHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync("package-manager2 --prune"))
+            .MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_The_Specified_Package_Manager_Can_Not_Be_Found()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new PackageManagerRepository(context);
+        await CopyFileAsync("packages.yml", repository.FilePath);
+
+        var options = new InstallOptions
+        {
+            PackageManager = "package-manager-3"
+        };
+
+        var command = new InstallCommand(repository, shell)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        var exception = await Should.ThrowAsync<EntityNotFoundException>(async () =>
+        {
+            await command.ExecuteAsync(options);
+        });
+        
+        // Arrange
+        exception.ShouldNotBeNull();
+        exception.Message.ShouldContain(options.PackageManager);
+    }
+    
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_The_Specified_Package_Exists_Already()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new PackageManagerRepository(context);
+        await CopyFileAsync("packages.yml", repository.FilePath);
+
+        var options = new InstallOptions
+        {
+            PackageManager = "package-manager-1",
+            Package = new []{"package01-01"}
+        };
+
+        var command = new InstallCommand(repository, shell)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await command.ExecuteAsync(options);
+        });
+        
+        // Arrange
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("PM-003");
+    }
+    
+    [Fact]
+    public async Task Should_Add_Package_When_It_Does_Not_Exist()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new PackageManagerRepository(context);
+        await CopyFileAsync("packages.yml", repository.FilePath);
+
+        var options = new InstallOptions
+        {
+            PackageManager = "package-manager-1",
+            Package = new []{"package01-00"}
+        };
+
+        var command = new InstallCommand(repository, shell)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Arrange
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 install -y", "package01-00"))
+            .MustHaveHappened();
+
+        var manager = await repository.GetAsync(options.PackageManager);
+        manager.Packages.ShouldContain(options.Package.First());
+    }
+
+    [Fact]
+    public async Task Should_Not_Add_The_Packages_When_The_Install_Failed()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 install -y", "package01-00"))
+            .Returns(new RunProgramResult
+            {
+                ExitCode = 999,
+                Output = new List<string>
+                {
+                    "package install failed"
+                }
+            });
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new PackageManagerRepository(context);
+        await CopyFileAsync("packages.yml", repository.FilePath);
+
+        var options = new InstallOptions
+        {
+            PackageManager = "package-manager-1",
+            Package = new []{"package01-00"}
+        };
+
+        var command = new InstallCommand(repository, shell)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Arrange
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 install -y", "package01-00"))
+            .MustHaveHappened();
+
+        var manager = await repository.GetAsync(options.PackageManager);
+        manager.Packages.ShouldNotContain(options.Package.First());
+    }
+}

--- a/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/packages.yml
+++ b/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/packages.yml
@@ -1,0 +1,27 @@
+﻿- name: package-manager-1
+  runs-on:
+    - Linux
+    - macOS
+    - Windows
+  description: A description for package manager 1
+  pre-install: package-manager-1 update
+  install: package-manager1 install -y
+  post-install: package-manager1 --prune
+  update: package-manager1 upgrade
+  packages:
+    - package01-01
+    - package01-02
+
+- name: package-manager-2
+  runs-on:
+    - Linux
+    - macOS
+    - Windows
+  description: A description for package manager 2
+  pre-install: package-manager-2 update
+  install: package-manager2 install -y
+  post-install: package-manager2 --prune
+  update: package-manager2 upgrade
+  packages:
+    - package02-01
+    - package02-02

--- a/test/FuseDigital.QuickSetup.Domain.Tests/PackageManagers/PackageManagerDomainServiceTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/PackageManagers/PackageManagerDomainServiceTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.Platforms;
+using Shouldly;
+using Volo.Abp;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.PackageManagers;
+
+public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
+{
+    [Fact]
+    public async Task Should_Execute_Pre_Install_And_Post_Install_Scripts_When_Provided()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var manager = CreatePackageManager();
+
+        // Act
+        await manager.InstallPackagesAsync(shell);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync(manager.PreInstall))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[0]))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[1]))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.PostInstall))
+            .MustHaveHappened();
+    }
+
+    private static PackageManager CreatePackageManager()
+    {
+        return new PackageManager
+        {
+            Name = "package-manager",
+            RunsOn = new[]
+            {
+                PlatformOperatingSystem.Linux,
+                PlatformOperatingSystem.macOS,
+                PlatformOperatingSystem.Windows,
+            },
+            PreInstall = "package-manager update",
+            Install = "package-manager install -y",
+            Update = "package-manager update && package-manager upgrade",
+            PostInstall = "package-manager clean",
+            Packages = new List<string>()
+            {
+                "package-01",
+                "package-02"
+            }
+        };
+    }
+
+    [Fact]
+    public async Task Should_Not_Execute_Pre_Install_And_Post_Install_Scripts_When_Not_Provided()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var manager = CreatePackageManager();
+        manager.PreInstall = "";
+        manager.PostInstall = "";
+
+        // Act
+        await manager.InstallPackagesAsync(shell);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync(manager.PreInstall))
+            .MustNotHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[0]))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[1]))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.PostInstall))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_Package_Manager_Is_Not_Configured_To_Run_On_Operating_System()
+    {
+        var shell = A.Fake<IShellDomainService>();
+        var manager = CreatePackageManager();
+        manager.RunsOn = new List<PlatformOperatingSystem>();
+
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await manager.InstallPackagesAsync(shell);
+        });
+        
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("PM-001");
+    }
+    
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_No_Install_Command_Specified()
+    {
+        var shell = A.Fake<IShellDomainService>();
+        var manager = CreatePackageManager();
+        manager.Install = "";
+
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await manager.InstallPackagesAsync(shell);
+        });
+        
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("PM-002");
+    }
+}


### PR DESCRIPTION

### Implement Package Management

Modeled the package management domain that will add packages and install
all packages for a given package manager.

### Implement the `install` command

The install command helps users quickly and easily install packages for
one or more package managers. It has options for specifying a specific
package manager and a specific package to install.

This commit includes the implementation of the install command and
related functionality, as well as documentation and testing.
