### PR TITLE
Fix Shell service to return correct output

### DIFF
--- a/src/FuseDigital.QuickSetup.Domain/Extensions/StreamReaderExtensions.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Extensions/StreamReaderExtensions.cs
@@ -1,0 +1,26 @@
+namespace FuseDigital.QuickSetup.Extensions;
+
+public static class StreamReaderExtensions
+{
+    public static async Task<IList<string>> ReadLinesAsync(this StreamReader reader)
+    {
+        var lines = new List<string>();
+        while (await reader.ReadLineAsync() is { } line)
+        {
+            lines.Add(line);
+        }
+
+        return lines;
+    }
+    
+    public static IList<string> ReadLines(this StreamReader reader)
+    {
+        var lines = new List<string>();
+        while (reader.ReadLine() is { } line)
+        {
+            lines.Add(line);
+        }
+
+        return lines;
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using FuseDigital.QuickSetup.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp;
@@ -145,13 +146,10 @@ public class VersionControlDomainService : DomainService, IVersionControlDomainS
 
         var startInfo = GitCommand(arguments);
         var process = Process.Start(startInfo);
-        var processOutput = process?.StandardOutput.ReadToEnd();
+        var output = process?.StandardOutput.ReadLines();
         process?.WaitForExit();
 
-        var output = processOutput?.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
-                     ?? Array.Empty<string>();
-
-        Logger.LogDebug("Output {Output}", output.ToList());
+        Logger.LogDebug("Output {Output}", output);
         return output;
     }
 

--- a/test/FuseDigital.QuickSetup.Domain.Tests/Platforms/ShellDomainServerTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/Platforms/ShellDomainServerTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
@@ -11,14 +12,18 @@ public class ShellDomainServerTests : QuickSetupDomainTestBase
     {
         // Arrange
         var shell = GetRequiredService<IShellDomainService>();
-        
+
+        var filename = "README.md";
+        Directory.CreateDirectory(Settings.UserProfile);
+        await File.WriteAllTextAsync(Path.Combine(Settings.UserProfile, filename), "# qup-empty-dotfiles");
+
         // Act
-        var result = await shell.RunProcessAsync("ls", "-a");
-        
+        var result = await shell.RunProcessAsync("ls");
+
         // Assert
         result.ShouldNotBeNull();
         result.ExitCode.ShouldBe(0);
-        result.Output.Count.ShouldBe(3);
+        result.Output.Count.ShouldBeGreaterThan(0);
     }
 
     [Fact]
@@ -26,10 +31,10 @@ public class ShellDomainServerTests : QuickSetupDomainTestBase
     {
         // Arrange
         var shell = GetRequiredService<IShellDomainService>();
-        
+
         // Act
         var result = await shell.RunProcessAsync("some-random-command", "--random-switch");
-        
+
         // Assert
         result.ShouldNotBeNull();
         result.ExitCode.ShouldBeGreaterThan(0);

--- a/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
@@ -18,7 +18,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
     private string RepoWorkingDirectory { get; }
     private string SecondRepoWorkingDirectory { get; }
     private string RemoteUrl { get; }
-    
+
     public VersionControlSystemTests()
     {
         _versionControlSystem = new VersionControlDomainService(Options)
@@ -35,7 +35,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
     {
         // Arrange
         LogDebug();
-        _versionControlSystem.Init(RemoteUrl, new[] {"--bare", "-b", BranchName});
+        _versionControlSystem.Init(RemoteUrl, new[] { "--bare", "-b", BranchName });
 
         // Act
         _versionControlSystem.Clone(RemoteUrl, RepoRelativePath);
@@ -145,7 +145,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
     {
         // Arrange
         LogDebug();
-        _versionControlSystem.Init(RemoteUrl, new[] {"--bare", "-b", BranchName});
+        _versionControlSystem.Init(RemoteUrl, new[] { "--bare", "-b", BranchName });
         await RenameBranch_Should_Change_The_Name_Of_The_Current_Branch();
 
         // Act
@@ -172,8 +172,10 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
         _versionControlSystem.AddAll();
 
         // Assert
-        _versionControlSystem
-            .Status()
+        var status = _versionControlSystem
+            .Status();
+
+        status
             .Count(x =>
                 x.Contains("new file:", StringComparison.InvariantCultureIgnoreCase)
                 && x.Contains(Filename, StringComparison.InvariantCultureIgnoreCase))
@@ -218,7 +220,7 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
     {
         // Arrange
         LogDebug();
-        _versionControlSystem.Init(RemoteUrl, new[] {"--bare", "-b", BranchName});
+        _versionControlSystem.Init(RemoteUrl, new[] { "--bare", "-b", BranchName });
         _versionControlSystem.Clone(RemoteUrl, RepoRelativePath);
         _versionControlSystem.WorkingDirectory = RepoWorkingDirectory;
         _versionControlSystem.SetConfig("user.email", "john@doe.com");


### PR DESCRIPTION
When a command begins running, it expects that three streams are already open, namely: standard input, standard output, and standard error.

Certain commands also use the error output stream as diagnostic output. The `RunProcessAsync` method only returns the error output stream if the exit code was not equal to 0, which resulted in some of the diagnostic output was not available for certain commands.

Changed the `RunProcessAsync` method to concat and return the standard output and error.