### PR TITLE
Move log file sink location

### DIFF
--- a/src/FuseDigital.QuickSetup.Cli/QuickSetupLoggingService.cs
+++ b/src/FuseDigital.QuickSetup.Cli/QuickSetupLoggingService.cs
@@ -21,7 +21,7 @@ public class QuickSetupLoggingService : ILoggingService
         set => LoggingLevel.MinimumLevel = _objectMapper.Map<LogLevel, LogEventLevel>(value);
     }
 
-    public string LogDirectory => Path.Combine(Settings.UserProfile, Settings.BaseDirectory, Settings.LogDirectory);
+    public string LogDirectory => Path.Combine(Settings.LocalApplicationDataPath, Settings.LogDirectory);
 
     private LoggingLevelSwitch LoggingLevel { get; } = new()
     {

--- a/src/FuseDigital.QuickSetup.Domain/QuickSetupOptions.cs
+++ b/src/FuseDigital.QuickSetup.Domain/QuickSetupOptions.cs
@@ -6,6 +6,9 @@ public class QuickSetupOptions
 
     public string BaseDirectory { get; set; } = ".qup";
 
+    public string LocalApplicationDataPath { get; set; } =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "QuickSetup");
+
     public string LogDirectory { get; set; } = "logs";
 
     private const char DirectorySeparatorChar = '/';

--- a/test/FuseDigital.QuickSetup.TestBase/TestBaseLoggingService.cs
+++ b/test/FuseDigital.QuickSetup.TestBase/TestBaseLoggingService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using FuseDigital.QuickSetup.Logging;
 using Microsoft.Extensions.Logging;
 using Serilog;
@@ -15,7 +16,7 @@ public class TestBaseLoggingService : ILoggingService
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Debug()
             .Enrich.FromLogContext()
-            .WriteTo.File($"qup-unit-test-logs.txt")
+            .WriteTo.File(Path.Combine(LogDirectory, "qup-unit-test-logs.txt"))
             .CreateLogger();
     }
 


### PR DESCRIPTION
The default setting is to sync all files and directories in the `.qup` folder. Previously the logging service was configured to sink all the application logs to the `~/.qup/logs` folder, which resulted in the logs being tracked and pushed to the remote repository when the `sync` command is executed.

Moved the log files to be be sinked to the Local Application Data folder instead.