### PR TITLE
Add `install` command status updates

### DIFF
--- a/src/FuseDigital.QuickSetup.Application/PackageManagers/InstallCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/PackageManagers/InstallCommand.cs
@@ -11,12 +11,14 @@ public class InstallCommand : QupCommandAsync, ITransientDependency
 {
     private readonly IPackageManagerRepository _repository;
     private readonly IShellDomainService _shell;
+    private readonly IConsoleService _console;
     private readonly PlatformOperatingSystem _currentOperatingSystem;
 
-    public InstallCommand(IPackageManagerRepository repository, IShellDomainService shell)
+    public InstallCommand(IPackageManagerRepository repository, IShellDomainService shell, IConsoleService console)
     {
         _repository = repository;
         _shell = shell;
+        _console = console;
         _currentOperatingSystem = PlatformEnvironment.CurrentOperatingSystem();
     }
 
@@ -50,20 +52,20 @@ public class InstallCommand : QupCommandAsync, ITransientDependency
 
         foreach (var packageManager in packageManagers)
         {
-            await packageManager.InstallPackagesAsync(_shell);
+            await packageManager.InstallPackagesAsync(_shell, _console);
         }
     }
 
     private async Task InstallPackageManagerAsync(string name)
     {
         var packageManager = await _repository.GetAsync(name);
-        await packageManager.InstallPackagesAsync(_shell);
+        await packageManager.InstallPackagesAsync(_shell, _console);
     }
 
     private async Task InstallPackage(string name, string package)
     {
         var packageManager = await _repository.GetAsync(name);
-        await packageManager.AddPackageAsync(package, _shell);
+        await packageManager.AddPackageAsync(package, _shell, _console);
         await _repository.UpdateAsync(packageManager);
     }
 }

--- a/src/FuseDigital.QuickSetup.Cli/FuseDigital.QuickSetup.Cli.csproj
+++ b/src/FuseDigital.QuickSetup.Cli/FuseDigital.QuickSetup.Cli.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\common.props"/>
+    <Import Project="..\..\common.props" />
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -27,23 +27,25 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0"/>
-        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0"/>
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0"/>
+        <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
+        <PackageReference Include="Figgle" Version="0.4.1" />
+        <PackageReference Include="Crayon" Version="2.0.69" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Volo.Abp.Autofac" Version="6.0.2"/>
+        <PackageReference Include="Volo.Abp.Autofac" Version="6.0.2" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\FuseDigital.QuickSetup.Application\FuseDigital.QuickSetup.Application.csproj"/>
-        <ProjectReference Include="..\FuseDigital.QuickSetup.Infrastructure\FuseDigital.QuickSetup.Infrastructure.csproj"/>
+        <ProjectReference Include="..\FuseDigital.QuickSetup.Application\FuseDigital.QuickSetup.Application.csproj" />
+        <ProjectReference Include="..\FuseDigital.QuickSetup.Infrastructure\FuseDigital.QuickSetup.Infrastructure.csproj" />
     </ItemGroup>
     
     <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/src/FuseDigital.QuickSetup.Cli/Program.cs
+++ b/src/FuseDigital.QuickSetup.Cli/Program.cs
@@ -2,6 +2,7 @@ using System;
 using Serilog;
 using System.Threading.Tasks;
 using FuseDigital.QuickSetup.Logging;
+using FuseDigital.QuickSetup.Platforms;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp;
 

--- a/src/FuseDigital.QuickSetup.Cli/QuickSetupConsoleService.cs
+++ b/src/FuseDigital.QuickSetup.Cli/QuickSetupConsoleService.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+using Crayon;
+using Figgle;
+using FuseDigital.QuickSetup.Platforms;
+using static Crayon.Output;
+
+namespace FuseDigital.QuickSetup.Cli;
+
+public class QuickSetupConsoleService : IConsoleService
+{
+    public Task WriteTitleAsync(string format, params object[] arg)
+    {
+        var header = FiggleFonts.Univers.Render(string.Format(format, arg));
+        Console.WriteLine(PrimaryColour().Text(header));
+        return Task.CompletedTask;
+    }
+
+    public Task WriteHeadingAsync(string format, params object[] arg)
+    {
+        var message = string.Format(format, arg);
+        Console.WriteLine(PrimaryColour().Bold(message));
+        Console.WriteLine();
+        return Task.CompletedTask;
+    }
+
+    public Task WriteLineAsync(string format = default, params object[] arg)
+    {
+        if (format != null)
+        {
+            Console.WriteLine(format, arg);
+        }
+
+        Console.WriteLine();
+
+        return Task.CompletedTask;
+    }
+
+    private IOutput PrimaryColour()
+    {
+        return Rgb(237, 50, 102);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/Entities/EntityAlreadyExistsException.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Entities/EntityAlreadyExistsException.cs
@@ -8,7 +8,7 @@ public class EntityAlreadyExistsException : BusinessException
     /// <summary>
     /// Exceptions are logged with the Error level by default. The Log level can be determined by the exception.
     /// </summary>
-    public LogLevel LogLevel { get; set; } = LogLevel.Warning;
+    public new LogLevel LogLevel { get; set; } = LogLevel.Warning;
 
     /// <summary>
     /// Type of the entity.

--- a/src/FuseDigital.QuickSetup.Domain/Platforms/IConsoleService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Platforms/IConsoleService.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Volo.Abp.DependencyInjection;
+
+namespace FuseDigital.QuickSetup.Platforms;
+
+public interface IConsoleService : ISingletonDependency
+{
+    Task WriteTitleAsync(
+        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, 
+        params object[] arg);
+
+    Task WriteHeadingAsync(
+        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format, 
+        params object[] arg);
+
+    Task WriteLineAsync(
+        [StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+        string format = default,
+        params object[] arg);
+}

--- a/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/InstallCommandTests.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/InstallCommandTests.cs
@@ -22,13 +22,14 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
     {
         // Arrange
         var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
 
         var context = GetRequiredService<IYamlContext>();
         var repository = new PackageManagerRepository(context);
         await CopyFileAsync("packages.yml", repository.FilePath);
 
         var options = new InstallOptions();
-        var command = new InstallCommand(repository, shell)
+        var command = new InstallCommand(repository, shell, console)
         {
             LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
         };
@@ -61,6 +62,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
     {
         // Arrange
         var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
 
         var context = GetRequiredService<IYamlContext>();
         var repository = new PackageManagerRepository(context);
@@ -71,7 +73,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
             PackageManager = "package-manager-1"
         };
 
-        var command = new InstallCommand(repository, shell)
+        var command = new InstallCommand(repository, shell, console)
         {
             LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
         };
@@ -104,6 +106,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
     {
         // Arrange
         var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
 
         var context = GetRequiredService<IYamlContext>();
         var repository = new PackageManagerRepository(context);
@@ -114,7 +117,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
             PackageManager = "package-manager-3"
         };
 
-        var command = new InstallCommand(repository, shell)
+        var command = new InstallCommand(repository, shell, console)
         {
             LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
         };
@@ -135,6 +138,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
     {
         // Arrange
         var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
 
         var context = GetRequiredService<IYamlContext>();
         var repository = new PackageManagerRepository(context);
@@ -146,7 +150,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
             Package = new []{"package01-01"}
         };
 
-        var command = new InstallCommand(repository, shell)
+        var command = new InstallCommand(repository, shell, console)
         {
             LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
         };
@@ -167,6 +171,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
     {
         // Arrange
         var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
 
         var context = GetRequiredService<IYamlContext>();
         var repository = new PackageManagerRepository(context);
@@ -178,7 +183,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
             Package = new []{"package01-00"}
         };
 
-        var command = new InstallCommand(repository, shell)
+        var command = new InstallCommand(repository, shell, console)
         {
             LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
         };
@@ -198,6 +203,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
     public async Task Should_Not_Add_The_Packages_When_The_Install_Failed()
     {
         // Arrange
+        var console = A.Fake<IConsoleService>();
         var shell = A.Fake<IShellDomainService>();
         A.CallTo(() => shell.RunProcessAsync("package-manager1 install -y", "package01-00"))
             .Returns(new RunProgramResult
@@ -219,7 +225,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
             Package = new []{"package01-00"}
         };
 
-        var command = new InstallCommand(repository, shell)
+        var command = new InstallCommand(repository, shell, console)
         {
             LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
         };

--- a/test/FuseDigital.QuickSetup.Domain.Tests/PackageManagers/PackageManagerDomainServiceTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/PackageManagers/PackageManagerDomainServiceTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FakeItEasy;
@@ -16,10 +15,11 @@ public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
     {
         // Arrange
         var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
         var manager = CreatePackageManager();
 
         // Act
-        await manager.InstallPackagesAsync(shell);
+        await manager.InstallPackagesAsync(shell, console);
 
         // Assert
         A.CallTo(() => shell.RunProcessAsync(manager.PreInstall))
@@ -60,12 +60,13 @@ public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
     {
         // Arrange
         var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
         var manager = CreatePackageManager();
         manager.PreInstall = "";
         manager.PostInstall = "";
 
         // Act
-        await manager.InstallPackagesAsync(shell);
+        await manager.InstallPackagesAsync(shell, console);
 
         // Assert
         A.CallTo(() => shell.RunProcessAsync(manager.PreInstall))
@@ -82,13 +83,14 @@ public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
     public async Task Should_Throw_An_Exception_When_Package_Manager_Is_Not_Configured_To_Run_On_Operating_System()
     {
         var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
         var manager = CreatePackageManager();
         manager.RunsOn = new List<PlatformOperatingSystem>();
 
         // Act
         var exception = await Should.ThrowAsync<BusinessException>(async () =>
         {
-            await manager.InstallPackagesAsync(shell);
+            await manager.InstallPackagesAsync(shell, console);
         });
         
         // Assert
@@ -100,13 +102,14 @@ public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
     public async Task Should_Throw_An_Exception_When_No_Install_Command_Specified()
     {
         var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
         var manager = CreatePackageManager();
         manager.Install = "";
 
         // Act
         var exception = await Should.ThrowAsync<BusinessException>(async () =>
         {
-            await manager.InstallPackagesAsync(shell);
+            await manager.InstallPackagesAsync(shell, console);
         });
         
         // Assert


### PR DESCRIPTION
Added an IConsoleService that abstract the implementation of the formatting the message.

Added a concrete implementation to the Cli project that uses Figgle Fonts and Crayon to format the Titles, Heading and standard text Lines before writing it to the command line console as standard output.

Updated the PackageManager domain entity `InstallPackagesAsync` and `AddPackageAsync` operations to output details information about the package manager and install status information.