### PR TITLE
Feature/update command

### DIFF
--- a/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/InstallOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/InstallOptions.cs
@@ -1,20 +1,37 @@
 using System;
 using System.Collections.Generic;
 using CommandLine;
+using CommandLine.Text;
 
 namespace FuseDigital.QuickSetup.PackageManagers.Dto;
 
-[Verb("install", HelpText = "install stuff")]
+[Verb("install", HelpText = "Install a specific package, packages for the specified package manager, or all package managers if none is specified.")]
 public class InstallOptions : QupCommandOptions
 {
-    [Value(1, MetaName = "package-manager", Required = false, HelpText = "")]
+    [Value(0, MetaName = "package-manager", Required = false, HelpText = "The package manager to install packages for (e.g., pip, npm).")]
     public string PackageManager { get; set; }
 
-    [Value(1, MetaName = "package", Required = false, HelpText = "")]
+    [Value(1, MetaName = "package", Required = false, HelpText = "The package to install and add to the package manager repository.")]
     public IEnumerable<string> Package { get; set; }
 
     public override Type GetCommandType()
     {
         return typeof(InstallCommand);
+    }
+
+    [Usage(ApplicationAlias = ApplicationAlias)]
+    public static IEnumerable<Example> Examples
+    {
+        get
+        {
+            yield return new Example("Install packages for all package managers",
+                new InstallOptions());
+
+            yield return new Example("Install packages for a specific package manager",
+                new InstallOptions {PackageManager = "apt"});
+
+            yield return new Example("Install and track a specific package.",
+                new InstallOptions {PackageManager = "apt", Package = new[] {"curl"}});
+        }
     }
 }

--- a/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/UpdateOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/UpdateOptions.cs
@@ -1,16 +1,31 @@
 using System;
+using System.Collections.Generic;
 using CommandLine;
+using CommandLine.Text;
 
 namespace FuseDigital.QuickSetup.PackageManagers.Dto;
 
-[Verb("update", HelpText = "update stuff")]
+[Verb("update", HelpText = "Updates all packages for the specified package manager, or all package managers if none is specified.")]
 public class UpdateOptions : QupCommandOptions
 {
-    [Value(1, MetaName = "package-manager", Required = false, HelpText = "")]
+    [Value(0, MetaName = "package-manager", Required = false, HelpText = "The package manager to update packages for (e.g., pip, npm).")]
     public string PackageManager { get; set; }
 
     public override Type GetCommandType()
     {
         return typeof(InstallCommand);
+    }
+    
+    [Usage(ApplicationAlias = ApplicationAlias)]
+    public static IEnumerable<Example> Examples
+    {
+        get
+        {
+            yield return new Example("Update packages for all package managers",
+                new UpdateOptions());
+
+            yield return new Example("Update packages for a specific package manager",
+                new UpdateOptions {PackageManager = "apt"});
+        }
     }
 }

--- a/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/UpdateOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/UpdateOptions.cs
@@ -1,0 +1,16 @@
+using System;
+using CommandLine;
+
+namespace FuseDigital.QuickSetup.PackageManagers.Dto;
+
+[Verb("update", HelpText = "update stuff")]
+public class UpdateOptions : QupCommandOptions
+{
+    [Value(1, MetaName = "package-manager", Required = false, HelpText = "")]
+    public string PackageManager { get; set; }
+
+    public override Type GetCommandType()
+    {
+        return typeof(InstallCommand);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/PackageManagers/UpdateCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/PackageManagers/UpdateCommand.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FuseDigital.QuickSetup.PackageManagers.Dto;
+using FuseDigital.QuickSetup.Platforms;
+using Volo.Abp.DependencyInjection;
+
+namespace FuseDigital.QuickSetup.PackageManagers;
+
+public class UpdateCommand : QupCommandAsync, ITransientDependency
+{
+    private readonly IPackageManagerRepository _repository;
+    private readonly IShellDomainService _shell;
+    private readonly IConsoleService _console;
+    private readonly PlatformOperatingSystem _currentOperatingSystem;
+
+    public UpdateCommand(IPackageManagerRepository repository, IShellDomainService shell, IConsoleService console)
+    {
+        _repository = repository;
+        _shell = shell;
+        _console = console;
+        _currentOperatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+    }
+
+    public override async Task ExecuteAsync(IQupCommandOptions options)
+    {
+        await base.ExecuteAsync(options);
+
+        var updateOptions = (UpdateOptions) options;
+        if (!string.IsNullOrEmpty(updateOptions.PackageManager))
+        {
+            await UpdatePackageManagerAsync(updateOptions.PackageManager);
+        }
+        else
+        {
+            await UpdateAsync();
+        }
+    }
+
+    private async Task UpdateAsync()
+    {
+        var packageManagers = await _repository
+            .GetListAsync(x => x.RunsOn.Contains(_currentOperatingSystem));
+
+        foreach (var packageManager in packageManagers)
+        {
+            await packageManager.UpdatePackagesAsync(_shell, _console);
+        }
+    }
+
+    private async Task UpdatePackageManagerAsync(string name)
+    {
+        var packageManager = await _repository.GetAsync(name);
+        await packageManager.UpdatePackagesAsync(_shell, _console);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/QupCommandOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/QupCommandOptions.cs
@@ -11,4 +11,6 @@ public abstract class QupCommandOptions : IQupCommandOptions
     public LogLevel Verbosity { get; set; }
 
     public abstract Type GetCommandType();
+
+    protected const string ApplicationAlias = "qup";
 }

--- a/src/FuseDigital.QuickSetup.Infrastructure/Yaml/YamlContext.cs
+++ b/src/FuseDigital.QuickSetup.Infrastructure/Yaml/YamlContext.cs
@@ -21,6 +21,7 @@ public class YamlContext : IYamlContext, ISingletonDependency
         var namingConvention = HyphenatedNamingConvention.Instance;
 
         _serializer = new SerializerBuilder()
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
             .WithNamingConvention(namingConvention)
             .Build();
 

--- a/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/UpdateCommandTests.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/UpdateCommandTests.cs
@@ -1,0 +1,107 @@
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.PackageManagers.Dto;
+using FuseDigital.QuickSetup.Platforms;
+using FuseDigital.QuickSetup.Repositories;
+using FuseDigital.QuickSetup.Yaml;
+using Shouldly;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Entities;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.PackageManagers;
+
+public class UpdateCommandTests : QuickSetupApplicationTestBase
+{
+    [Fact]
+    public async Task Should_Update_Packages_For_All_Package_Managers()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new PackageManagerRepository(context);
+        await CopyFileAsync("packages.yml", repository.FilePath);
+
+        var options = new UpdateOptions();
+        var command = new UpdateCommand(repository, shell, console)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 upgrade"))
+            .MustHaveHappened();
+
+        A.CallTo(() => shell.RunProcessAsync("package-manager2 upgrade"))
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Update_Packages_Only_For_Specified_Package_Manager()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new PackageManagerRepository(context);
+        await CopyFileAsync("packages.yml", repository.FilePath);
+
+        var options = new UpdateOptions
+        {
+            PackageManager = "package-manager-1"
+        };
+
+        var command = new UpdateCommand(repository, shell, console)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync("package-manager1 upgrade"))
+            .MustHaveHappened();
+        
+        A.CallTo(() => shell.RunProcessAsync("package-manager2 upgrade"))
+            .MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_The_Specified_Package_Manager_Can_Not_Be_Found()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new PackageManagerRepository(context);
+        await CopyFileAsync("packages.yml", repository.FilePath);
+
+        var options = new UpdateOptions
+        {
+            PackageManager = "package-manager-3"
+        };
+
+        var command = new UpdateCommand(repository, shell, console)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        var exception = await Should.ThrowAsync<EntityNotFoundException>(async () =>
+        {
+            await command.ExecuteAsync(options);
+        });
+        
+        // Arrange
+        exception.ShouldNotBeNull();
+        exception.Message.ShouldContain(options.PackageManager);
+    }
+}

--- a/test/FuseDigital.QuickSetup.Domain.Tests/PackageManagers/InstallPackageManagerTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/PackageManagers/InstallPackageManagerTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.Platforms;
+using Shouldly;
+using Volo.Abp;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.PackageManagers;
+
+public class InstallPackageManagerTests : QuickSetupDomainTestBase
+{
+    [Fact]
+    public async Task Should_Execute_Pre_Install_And_Post_Install_Scripts_When_Provided()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreatePackageManager();
+
+        // Act
+        await manager.InstallPackagesAsync(shell, console);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync(manager.PreInstall))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[0]))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[1]))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.PostInstall))
+            .MustHaveHappened();
+    }
+
+    private static PackageManager CreatePackageManager()
+    {
+        return new PackageManager
+        {
+            Name = "package-manager",
+            RunsOn = new[]
+            {
+                PlatformOperatingSystem.Linux,
+                PlatformOperatingSystem.macOS,
+                PlatformOperatingSystem.Windows,
+            },
+            PreInstall = "package-manager update",
+            Install = "package-manager install -y",
+            Update = "package-manager update && package-manager upgrade",
+            PostInstall = "package-manager clean",
+            Packages = new List<string>()
+            {
+                "package-01",
+                "package-02"
+            }
+        };
+    }
+
+    [Fact]
+    public async Task Should_Not_Execute_Pre_Install_And_Post_Install_Scripts_When_Not_Provided()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreatePackageManager();
+        manager.PreInstall = "";
+        manager.PostInstall = "";
+
+        // Act
+        await manager.InstallPackagesAsync(shell, console);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync(manager.PreInstall))
+            .MustNotHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[0]))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[1]))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.PostInstall))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_Package_Manager_Is_Not_Configured_To_Run_On_Operating_System()
+    {
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreatePackageManager();
+        manager.RunsOn = new List<PlatformOperatingSystem>();
+
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await manager.InstallPackagesAsync(shell, console);
+        });
+        
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("PM-001");
+    }
+    
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_No_Install_Command_Specified()
+    {
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreatePackageManager();
+        manager.Install = "";
+
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await manager.InstallPackagesAsync(shell, console);
+        });
+        
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("PM-002");
+    }
+}

--- a/test/FuseDigital.QuickSetup.Domain.Tests/PackageManagers/UpdatePackageManagerTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/PackageManagers/UpdatePackageManagerTests.cs
@@ -8,10 +8,10 @@ using Xunit;
 
 namespace FuseDigital.QuickSetup.PackageManagers;
 
-public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
+public class UpdatePackageManagerTests : QuickSetupDomainTestBase
 {
     [Fact]
-    public async Task Should_Execute_Pre_Install_And_Post_Install_Scripts_When_Provided()
+    public async Task Should_Execute_Update_When_Provided()
     {
         // Arrange
         var shell = A.Fake<IShellDomainService>();
@@ -19,16 +19,10 @@ public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
         var manager = CreatePackageManager();
 
         // Act
-        await manager.InstallPackagesAsync(shell, console);
+        await manager.UpdatePackagesAsync(shell, console);
 
         // Assert
-        A.CallTo(() => shell.RunProcessAsync(manager.PreInstall))
-            .MustHaveHappened();
-        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[0]))
-            .MustHaveHappened();
-        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[1]))
-            .MustHaveHappened();
-        A.CallTo(() => shell.RunProcessAsync(manager.PostInstall))
+        A.CallTo(() => shell.RunProcessAsync(manager.Update))
             .MustHaveHappened();
     }
 
@@ -56,30 +50,6 @@ public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
     }
 
     [Fact]
-    public async Task Should_Not_Execute_Pre_Install_And_Post_Install_Scripts_When_Not_Provided()
-    {
-        // Arrange
-        var shell = A.Fake<IShellDomainService>();
-        var console = A.Fake<IConsoleService>();
-        var manager = CreatePackageManager();
-        manager.PreInstall = "";
-        manager.PostInstall = "";
-
-        // Act
-        await manager.InstallPackagesAsync(shell, console);
-
-        // Assert
-        A.CallTo(() => shell.RunProcessAsync(manager.PreInstall))
-            .MustNotHaveHappened();
-        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[0]))
-            .MustHaveHappened();
-        A.CallTo(() => shell.RunProcessAsync(manager.Install, manager.Packages[1]))
-            .MustHaveHappened();
-        A.CallTo(() => shell.RunProcessAsync(manager.PostInstall))
-            .MustNotHaveHappened();
-    }
-
-    [Fact]
     public async Task Should_Throw_An_Exception_When_Package_Manager_Is_Not_Configured_To_Run_On_Operating_System()
     {
         var shell = A.Fake<IShellDomainService>();
@@ -90,7 +60,7 @@ public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
         // Act
         var exception = await Should.ThrowAsync<BusinessException>(async () =>
         {
-            await manager.InstallPackagesAsync(shell, console);
+            await manager.UpdatePackagesAsync(shell, console);
         });
         
         // Assert
@@ -99,21 +69,21 @@ public class PackageManagerDomainServiceTests : QuickSetupDomainTestBase
     }
     
     [Fact]
-    public async Task Should_Throw_An_Exception_When_No_Install_Command_Specified()
+    public async Task Should_Throw_An_Exception_When_No_Update_Command_Specified()
     {
         var shell = A.Fake<IShellDomainService>();
         var console = A.Fake<IConsoleService>();
         var manager = CreatePackageManager();
-        manager.Install = "";
+        manager.Update = "";
 
         // Act
         var exception = await Should.ThrowAsync<BusinessException>(async () =>
         {
-            await manager.InstallPackagesAsync(shell, console);
+            await manager.UpdatePackagesAsync(shell, console);
         });
         
         // Assert
         exception.ShouldNotBeNull();
-        exception.Code.ShouldBe("PM-002");
+        exception.Code.ShouldBe("PM-003");
     }
 }


### PR DESCRIPTION

### Omit null values when serialising Yaml

Currently properties with null values are being added when saving a Yaml
repository. Added the options to omit null values when serialising.

### Implement `update` command

The update command helps users easily update packages for one or more
package managers. It has an option for specifying a specific package
manager to update.

### Improve help text

Improved the help text by adding usage examples for the `install` and
`update` commands.
