### PR TITLE
Fix `update` command options

### DIFF
--- a/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/UpdateOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/PackageManagers/Dto/UpdateOptions.cs
@@ -13,7 +13,7 @@ public class UpdateOptions : QupCommandOptions
 
     public override Type GetCommandType()
     {
-        return typeof(InstallCommand);
+        return typeof(UpdateCommand);
     }
     
     [Usage(ApplicationAlias = ApplicationAlias)]

--- a/src/FuseDigital.QuickSetup.Application/PackageManagers/UpdateCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/PackageManagers/UpdateCommand.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using FuseDigital.QuickSetup.PackageManagers.Dto;
 using FuseDigital.QuickSetup.Platforms;
@@ -40,7 +38,7 @@ public class UpdateCommand : QupCommandAsync, ITransientDependency
     private async Task UpdateAsync()
     {
         var packageManagers = await _repository
-            .GetListAsync(x => x.RunsOn.Contains(_currentOperatingSystem));
+            .GetListAsync(x => x.RunsOn.Contains(_currentOperatingSystem) && !string.IsNullOrEmpty(x.Update));
 
         foreach (var packageManager in packageManagers)
         {


### PR DESCRIPTION
The update options was set to start the install command instead of the update command, causing an exception being thrown during when the command is executed via the command line.