### PR TITLE
Remove standard input, output and error redirect.

### DIFF
--- a/src/FuseDigital.QuickSetup.Domain/PackageManagers/PackageManager.cs
+++ b/src/FuseDigital.QuickSetup.Domain/PackageManagers/PackageManager.cs
@@ -96,8 +96,7 @@ public class PackageManager : Entity
         await console.WriteLineAsync("Installing {0}", package);
 
         var result = await shell.RunProcessAsync(Install, package);
-
-        if (result.ExitCode == 0)
+        if (result == 0)
         {
             Packages.Add(package);
             Packages = Packages.OrderBy(x => x).ToList();
@@ -107,7 +106,7 @@ public class PackageManager : Entity
     public async Task UpdatePackagesAsync(IShellDomainService shell, IConsoleService console)
     {
         CheckOperatingSystem();
-        
+
         if (string.IsNullOrEmpty(Update))
         {
             throw new BusinessException("PM-003",
@@ -115,8 +114,6 @@ public class PackageManager : Entity
         }
 
         await WritePackageManagerInfoAsync(console);
-        var packages = Packages ?? new List<string>();
-        await console.WriteLineAsync("Updating {0} package(s)", packages.Count);
         await shell.RunProcessAsync(Update);
     }
 }

--- a/src/FuseDigital.QuickSetup.Domain/Platforms/DefaultShellAttribute.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Platforms/DefaultShellAttribute.cs
@@ -1,14 +1,19 @@
+using Volo.Abp;
+
 namespace FuseDigital.QuickSetup.Platforms;
 
 public class DefaultShellAttribute : Attribute
 {
-    public string Program { get; set; }
+    public string Program { get; }
 
-    public string ExitCommand { get; set; }
+    public string CommandArgument { get; }
 
-    public DefaultShellAttribute(string program, string exitCommand = "exit")
+    public DefaultShellAttribute(string program, string commandArgument)
     {
+        Check.NotNullOrEmpty(program, nameof(program));
+        Check.NotNullOrEmpty(commandArgument, nameof(commandArgument));
+
         Program = program;
-        ExitCommand = exitCommand;
+        CommandArgument = commandArgument;
     }
 }

--- a/src/FuseDigital.QuickSetup.Domain/Platforms/IShellDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Platforms/IShellDomainService.cs
@@ -5,5 +5,5 @@ namespace FuseDigital.QuickSetup.Platforms;
 
 public interface IShellDomainService : IDomainService
 {
-    Task<RunProgramResult> RunProcessAsync(params string[] arguments);
+    Task<int> RunProcessAsync(params string[] arguments);
 }

--- a/src/FuseDigital.QuickSetup.Domain/Platforms/PlatformOperatingSystem.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Platforms/PlatformOperatingSystem.cs
@@ -2,12 +2,12 @@ namespace FuseDigital.QuickSetup.Platforms;
 
 public enum PlatformOperatingSystem
 {
-    [DefaultShell("bash")]
+    [DefaultShell("bash", "-c")]
     Linux,
 
-    [DefaultShellAttribute("bash")]
+    [DefaultShellAttribute("bash", "-c")]
     macOS,
 
-    [DefaultShell("cmd.exe")]
+    [DefaultShell("cmd", "/C")]
     Windows,
 }

--- a/src/FuseDigital.QuickSetup.Domain/Platforms/ShellDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Platforms/ShellDomainService.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics;
-using FuseDigital.QuickSetup.Extensions;
-using FuseDigital.QuickSetup.Platforms.Dto;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Volo.Abp.Domain.Services;
@@ -11,22 +9,35 @@ public class ShellDomainService : DomainService, IShellDomainService
 {
     private QuickSetupOptions Settings { get; }
     private string ShellProgram { get; }
-    private string ShellExitCommand { get; }
+    private string ShellCommandArgument { get; }
 
     public ShellDomainService(IOptions<QuickSetupOptions> options)
     {
         Settings = options.Value;
         var shellOptions = PlatformEnvironment.DefaultShell();
         ShellProgram = shellOptions.Program;
-        ShellExitCommand = shellOptions.ExitCommand;
+        ShellCommandArgument = shellOptions.CommandArgument;
     }
 
-    public async Task<RunProgramResult> RunProcessAsync(params string[] arguments)
+    public async Task<int> RunProcessAsync(params string[] arguments)
     {
-        var startInfo = CreateProcessStartInfo(ShellProgram);
+        var command = arguments
+            .JoinAsString(" ")
+            .Replace("\"", "\"\"");
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = ShellProgram,
+            Arguments = $"{ShellCommandArgument} \"{command}\"",
+            UseShellExecute = false,
+            RedirectStandardInput = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            WorkingDirectory = Settings.UserProfile ?? ""
+        };
 
         Logger.LogDebug("Execute {Program} from {WorkingDirectory}", ShellProgram, startInfo.WorkingDirectory);
-        Logger.LogDebug("{Program} {Arguments}", ShellProgram, arguments);
+        Logger.LogDebug("{Program} {Arguments}", startInfo.FileName, startInfo.Arguments);
 
         if (!string.IsNullOrEmpty(startInfo.WorkingDirectory) && !Directory.Exists(startInfo.WorkingDirectory))
         {
@@ -36,42 +47,11 @@ public class ShellDomainService : DomainService, IShellDomainService
         var process = Process.Start(startInfo);
         if (process == null)
         {
-            return new RunProgramResult
-            {
-                ExitCode = 1,
-            };
+            return 1;
         }
 
-        var args = arguments.JoinAsString(" ");
-        await process.StandardInput.WriteLineAsync(args);
-        await process.StandardInput.WriteLineAsync(ShellExitCommand);
-        var errorLines = await process.StandardError.ReadLinesAsync();
-        var outputLines = await process.StandardOutput.ReadLinesAsync();
         await process.WaitForExitAsync();
 
-        Logger.LogDebug("program {Program} output {Output}", ShellProgram, outputLines);
-        Logger.LogDebug("program {Program} errors {Error}", ShellProgram, errorLines);
-
-        var output = outputLines.Concat(errorLines).ToList();
-        Logger.LogDebug("program {Program} lines {Output}", ShellProgram, output);
-
-        return new RunProgramResult
-        {
-            ExitCode = process.ExitCode,
-            Output = output,
-        };
-    }
-
-    private ProcessStartInfo CreateProcessStartInfo(string program)
-    {
-        return new ProcessStartInfo
-        {
-            FileName = program,
-            UseShellExecute = false,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            WorkingDirectory = Settings.UserProfile ?? ""
-        };
+        return process.ExitCode;
     }
 }

--- a/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/InstallCommandTests.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/PackageManagers/InstallCommandTests.cs
@@ -206,14 +206,7 @@ public class InstallCommandTests : QuickSetupApplicationTestBase
         var console = A.Fake<IConsoleService>();
         var shell = A.Fake<IShellDomainService>();
         A.CallTo(() => shell.RunProcessAsync("package-manager1 install -y", "package01-00"))
-            .Returns(new RunProgramResult
-            {
-                ExitCode = 999,
-                Output = new List<string>
-                {
-                    "package install failed"
-                }
-            });
+            .Returns(999);
 
         var context = GetRequiredService<IYamlContext>();
         var repository = new PackageManagerRepository(context);

--- a/test/FuseDigital.QuickSetup.Domain.Tests/Platforms/ShellDomainServerTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/Platforms/ShellDomainServerTests.cs
@@ -21,9 +21,7 @@ public class ShellDomainServerTests : QuickSetupDomainTestBase
         var result = await shell.RunProcessAsync("ls");
 
         // Assert
-        result.ShouldNotBeNull();
-        result.ExitCode.ShouldBe(0);
-        result.Output.Count.ShouldBeGreaterThan(0);
+        result.ShouldBe(0);
     }
 
     [Fact]
@@ -36,8 +34,6 @@ public class ShellDomainServerTests : QuickSetupDomainTestBase
         var result = await shell.RunProcessAsync("some-random-command", "--random-switch");
 
         // Assert
-        result.ShouldNotBeNull();
-        result.ExitCode.ShouldBeGreaterThan(0);
-        result.Output.Count.ShouldBeGreaterThan(0);
+        result.ShouldBeGreaterThan(0);
     }
 }


### PR DESCRIPTION

The previous implementation redirected the shell standard input, output, and error. It also used the standard input to provide a command script to the shell and required the exit command to signal when to stop the process, causing the standard error and output from the process to only be available after the completion of the process is completed.

Changed the shell service to instead use the command switch for the shell for each environment and execute the command as an inline script, thus removing the requirement to redirect the standard input, output, and error. The result is that the output is streamed directly to the console, creating a better user experience.