### PR TITLE
Implement `link` command

### DIFF
--- a/src/FuseDigital.QuickSetup.Application/LinkManagers/Dto/LinkOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/LinkManagers/Dto/LinkOptions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using CommandLine;
+using CommandLine.Text;
+
+namespace FuseDigital.QuickSetup.LinkManagers.Dto;
+
+[Verb("link", HelpText = "Create symbolic links between files or folders")]
+public class LinkOptions : QupCommandOptions
+{
+    [Value(0, MetaName = "source", Required = false, HelpText = "The source path of the file or directory")]
+    public string Source { get; set; }
+    
+    [Value(1, MetaName = "target", Required = false, HelpText = "The target path of the new link")]
+    public string Target { get; set; }
+    
+    public override Type GetCommandType()
+    {
+        return typeof(LinkCommand);
+    }
+    
+    [Usage(ApplicationAlias = ApplicationAlias)]
+    public static IEnumerable<Example> Examples
+    {
+        get
+        {
+            yield return new Example("Create all the links for current operating system.",
+                new LinkOptions());
+
+            yield return new Example("Create and track a new link.",
+                new LinkOptions {Source = "~/.qup/host", Target = "/etc/host"});
+        }
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/LinkManagers/LinkCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/LinkManagers/LinkCommand.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using FuseDigital.QuickSetup.LinkManagers.Dto;
+using FuseDigital.QuickSetup.Platforms;
+using Volo.Abp.DependencyInjection;
+
+namespace FuseDigital.QuickSetup.LinkManagers;
+
+public class LinkCommand : QupCommandAsync, ITransientDependency
+{
+    private readonly ILinkManagerRepository _repository;
+    private readonly IShellDomainService _shell;
+    private readonly IConsoleService _console;
+    private readonly PlatformOperatingSystem _currentOperatingSystem;
+
+    public LinkCommand(ILinkManagerRepository repository, IShellDomainService shell, IConsoleService console)
+    {
+        _repository = repository;
+        _shell = shell;
+        _console = console;
+        _currentOperatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+    }
+
+    public override async Task ExecuteAsync(IQupCommandOptions options)
+    {
+        await base.ExecuteAsync(options);
+
+        var linkOptions = (LinkOptions) options;
+        if (string.IsNullOrEmpty(linkOptions.Source) && string.IsNullOrEmpty(linkOptions.Target))
+        {
+            var linkManager = await _repository.GetAsync(_currentOperatingSystem);
+            await linkManager.CreateLinksAsync(_shell, _console);
+        }
+        else
+        {
+            var link = new Link(linkOptions.Source, linkOptions.Target);
+            var linkManager = await _repository.FindAsync(_currentOperatingSystem) ?? new LinkManager();
+            await linkManager.AddLinkAsync(link, _shell, _console);
+            await _repository.InsertOrUpdateAsync(linkManager);
+        }
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/QuickSetupAppService.cs
+++ b/src/FuseDigital.QuickSetup.Application/QuickSetupAppService.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Volo.Abp;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Entities;
+using Volo.Abp.Validation;
 
 namespace FuseDigital.QuickSetup;
 
@@ -36,11 +37,8 @@ public class QuickSetupAppService : ApplicationService
             await parserResult.WithParsedAsync<IQupCommandOptions>(RunCommandAsync);
             await parserResult.WithNotParsedAsync(errors => DisplayHelpAsync(parserResult, errors));
         }
-        catch (EntityNotFoundException exception)
-        {
-            Logger.LogBusinessException(exception);
-        }
-        catch (BusinessException exception)
+        catch (Exception exception)
+            when (exception is AbpValidationException or EntityNotFoundException or BusinessException)
         {
             Logger.LogBusinessException(exception);
         }

--- a/src/FuseDigital.QuickSetup.Domain/Entities/QupEntity.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Entities/QupEntity.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+using Volo.Abp.Domain.Entities;
+
+namespace FuseDigital.QuickSetup.Entities;
+
+public abstract class QupEntity : Entity
+{
+    public override object[] GetKeys()
+    {
+        return GetType().GetProperties()
+            .Where(prop => prop.IsDefined(typeof(KeyAttribute), false))
+            .Select(x => x.GetValue(this))
+            .ToArray();
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/Extensions/EntityExtensions.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Extensions/EntityExtensions.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+using Volo.Abp.Validation;
+
+namespace FuseDigital.QuickSetup.Extensions;
+
+public static class EntityExtensions
+{
+    public static void ValidateModel<TEntity>(this TEntity entity)
+    {
+        var modelValidationContext = new ValidationContext(entity, serviceProvider: null, items: null);
+        var modelValidationResults = new List<ValidationResult>();
+        Validator.TryValidateObject(entity, modelValidationContext, modelValidationResults, true);
+
+        if (modelValidationResults.Count > 0)
+        {
+            throw new AbpValidationException(null, modelValidationResults);
+        }
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/LinkManagers/ILinkManagerRepository.cs
+++ b/src/FuseDigital.QuickSetup.Domain/LinkManagers/ILinkManagerRepository.cs
@@ -1,0 +1,13 @@
+using FuseDigital.QuickSetup.Platforms;
+using Volo.Abp.Domain.Repositories;
+
+namespace FuseDigital.QuickSetup.LinkManagers;
+
+public interface ILinkManagerRepository : IRepository<LinkManager>
+{
+    Task<LinkManager> GetAsync(PlatformOperatingSystem runsOn);
+
+    Task<LinkManager> FindAsync(PlatformOperatingSystem runsOn);
+
+    Task<LinkManager> InsertOrUpdateAsync(LinkManager linkManager);
+}

--- a/src/FuseDigital.QuickSetup.Domain/LinkManagers/Link.cs
+++ b/src/FuseDigital.QuickSetup.Domain/LinkManagers/Link.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using FuseDigital.QuickSetup.Entities;
+
+namespace FuseDigital.QuickSetup.LinkManagers;
+
+public class Link : QupEntity
+{
+    [Key]
+    [Required]
+    public string Target { get; set; }
+
+    [Key]
+    [Required]
+    public string Source { get; set; }
+
+    public Link()
+    {
+    }
+
+    public Link(string source, string target)
+    {
+        Source = source;
+        Target = target;
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/LinkManagers/LinkManager.Helpers.cs
+++ b/src/FuseDigital.QuickSetup.Domain/LinkManagers/LinkManager.Helpers.cs
@@ -1,0 +1,50 @@
+using FuseDigital.QuickSetup.Platforms;
+using Volo.Abp;
+
+namespace FuseDigital.QuickSetup.LinkManagers;
+
+public partial class LinkManager
+{
+    private void CheckOperatingSystem()
+    {
+        var operatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+        if (!RunsOn.Equals(operatingSystem))
+        {
+            throw new BusinessException("LM-001",
+                $"Link manager is not configured to run on {operatingSystem}");
+        }
+    }
+    
+    private void CheckCreateLinkFormat()
+    {
+        if (string.IsNullOrEmpty(CreateLinkFormat))
+        {
+            throw new BusinessException("LM-002",
+                $"No create link format specified for the {RunsOn} link manager");
+        }
+
+        if (!CreateLinkFormat.Contains("${source}", StringComparison.InvariantCultureIgnoreCase))
+        {
+            throw new BusinessException("LM-003",
+                "The create link format does not contain a ${source} placeholder");
+        }
+        
+        if (!CreateLinkFormat.Contains("${target}", StringComparison.InvariantCultureIgnoreCase))
+        {
+            throw new BusinessException("LM-004",
+                "The create link format does not contain a ${target} placeholder");
+        }
+    }
+
+    private async Task<int> RunCreateLinkCommandAsync(Link link, IShellDomainService shell, IConsoleService console)
+    {
+        await console.WriteLineAsync($"Create Link from {link.Source} to {link.Target}");
+        return await shell.RunProcessAsync(GenerateCreateLinkCommand(link));
+    }
+
+    private async Task WriteDescriptionAsync(IConsoleService console)
+    {
+        await console.WriteHeadingAsync(RunsOn.ToString());
+        await console.WriteLineAsync(Description);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/LinkManagers/LinkManager.Model.cs
+++ b/src/FuseDigital.QuickSetup.Domain/LinkManagers/LinkManager.Model.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using FuseDigital.QuickSetup.Platforms;
+
+namespace FuseDigital.QuickSetup.LinkManagers;
+
+public partial class LinkManager
+{
+    [Key]
+    [Display(Description = "The target operating system")]
+    public PlatformOperatingSystem RunsOn { get; set; }
+
+    [Display(Description = "The description of the actions performed by the specified create link command.")]
+    public string Description { get; set; } = "Create a symbolic link from the target to the source";
+
+    [Required]
+    [Display(Description = "The command format to create the symbolic links with ${source} and ${target} placeholders")]
+    public string CreateLinkFormat { get; set; }
+
+    [Required]
+    [Display(Description = "The operating system that this link applies on")]
+    public IList<Link> Links { get; set; } = new List<Link>();
+}

--- a/src/FuseDigital.QuickSetup.Domain/LinkManagers/LinkManager.cs
+++ b/src/FuseDigital.QuickSetup.Domain/LinkManagers/LinkManager.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel.DataAnnotations;
+using FuseDigital.QuickSetup.Entities;
+using FuseDigital.QuickSetup.Extensions;
+using FuseDigital.QuickSetup.Platforms;
+using Volo.Abp;
+
+namespace FuseDigital.QuickSetup.LinkManagers;
+
+public partial class LinkManager : QupEntity
+{
+    public LinkManager()
+    {
+        RunsOn = PlatformEnvironment.CurrentOperatingSystem();
+        CreateLinkFormat = RunsOn.GetAttribute<DefaultLinkCommandAttribute>().Format;
+    }
+
+    public async Task CreateLinksAsync(IShellDomainService shell, IConsoleService console)
+    {
+        CheckOperatingSystem();
+        CheckCreateLinkFormat();
+        await WriteDescriptionAsync(console);
+
+        for (var index = 0; index < Links.Count; index++)
+        {
+            await console.WriteLineAsync();
+            await console.WriteLineAsync($"[{index + 1}/{Links.Count}]");
+            await RunCreateLinkCommandAsync(Links[index], shell, console);
+        }
+    }
+
+    public string GenerateCreateLinkCommand(Link link)
+    {
+        return CreateLinkFormat
+            .Replace("${source}", link.Source, StringComparison.InvariantCultureIgnoreCase)
+            .Replace("${target}", link.Target, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    public async Task AddLinkAsync(Link link, IShellDomainService shell, IConsoleService console)
+    {
+        link.ValidateModel();
+        CheckOperatingSystem();
+        CheckCreateLinkFormat();
+
+        var source = link.Source;
+        var target = link.Target;
+
+        var exists = Links.Any(x =>
+            x.Source.Equals(source, StringComparison.InvariantCultureIgnoreCase)
+            && x.Target.Equals(target, StringComparison.InvariantCultureIgnoreCase));
+
+        if (exists)
+        {
+            throw new BusinessException("LM-001", $"Link from {source} to {target} already exists");
+        }
+
+        await WriteDescriptionAsync(console);
+        var result = await RunCreateLinkCommandAsync(link, shell, console);
+        if (result == 0)
+        {
+            Links.Add(link);
+            Links = Links.OrderBy(x => x.Source).ToList();
+        }
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/PackageManagers/PackageManager.cs
+++ b/src/FuseDigital.QuickSetup.Domain/PackageManagers/PackageManager.cs
@@ -1,12 +1,13 @@
 using System.ComponentModel.DataAnnotations;
+using FuseDigital.QuickSetup.Entities;
 using FuseDigital.QuickSetup.Platforms;
 using Volo.Abp;
-using Volo.Abp.Domain.Entities;
 
 namespace FuseDigital.QuickSetup.PackageManagers;
 
-public class PackageManager : Entity
+public class PackageManager : QupEntity
 {
+    [Key]
     [Display(Description = "The name of the package manager")]
     [Required]
     [RegularExpression(@"^[a-zA-Z0-9_-]+$")]
@@ -33,11 +34,6 @@ public class PackageManager : Entity
 
     [Display(Description = "The list of packages that are being maintained by the package manager")]
     public IList<string> Packages { get; set; } = new List<string>();
-
-    public override object[] GetKeys()
-    {
-        return new object[] {Name};
-    }
 
     public async Task InstallPackagesAsync(IShellDomainService shell, IConsoleService console)
     {

--- a/src/FuseDigital.QuickSetup.Domain/Platforms/DefaultLinkCommandAttribute.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Platforms/DefaultLinkCommandAttribute.cs
@@ -1,0 +1,11 @@
+namespace FuseDigital.QuickSetup.Platforms;
+
+public class DefaultLinkCommandAttribute : Attribute
+{
+    public string Format { get; set; }
+
+    public DefaultLinkCommandAttribute(string format)
+    {
+        Format = format;
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/Platforms/PlatformOperatingSystem.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Platforms/PlatformOperatingSystem.cs
@@ -3,11 +3,14 @@ namespace FuseDigital.QuickSetup.Platforms;
 public enum PlatformOperatingSystem
 {
     [DefaultShell("bash", "-c")]
+    [DefaultLinkCommand("sudo ln -sfv ${source} ${target}")]
     Linux,
 
-    [DefaultShellAttribute("bash", "-c")]
+    [DefaultShell("bash", "-c")]
+    [DefaultLinkCommand("sudo ln -sfv ${source} ${target}")]
     macOS,
 
     [DefaultShell("cmd", "/C")]
+    [DefaultLinkCommand("mklink /j ${target} ${source}")]
     Windows,
 }

--- a/src/FuseDigital.QuickSetup.Domain/Projects/Project.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Projects/Project.cs
@@ -1,20 +1,15 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using FuseDigital.QuickSetup.Entities;
 using FuseDigital.QuickSetup.VersionControlSystems;
-using Volo.Abp.Domain.Entities;
 
 namespace FuseDigital.QuickSetup.Projects;
 
-public class Project : Entity
+public class Project : QupEntity
 {
     [Key]
     public string RelativePath { get; set; }
 
     public string Repository { get; set; }
-
-    public override object[] GetKeys()
-    {
-        return new object[] {RelativePath};
-    }
 
     public void Clone(IVersionControlDomainService versionControl)
     {

--- a/src/FuseDigital.QuickSetup.Infrastructure/Repositories/LinkManagerRepository.cs
+++ b/src/FuseDigital.QuickSetup.Infrastructure/Repositories/LinkManagerRepository.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using FuseDigital.QuickSetup.LinkManagers;
+using FuseDigital.QuickSetup.Platforms;
+using FuseDigital.QuickSetup.Yaml;
+using Volo.Abp.Domain.Entities;
+
+namespace FuseDigital.QuickSetup.Repositories;
+
+public class LinkManagerRepository : YamlRepository<LinkManager>, ILinkManagerRepository
+{
+    public override string FileName => "links.yml";
+
+    public LinkManagerRepository(IYamlContext context) : base(context)
+    {
+    }
+
+    public override Func<LinkManager, object> SortOrder<TKey>() => link => link.RunsOn;
+
+    public async Task<LinkManager> GetAsync(PlatformOperatingSystem runsOn)
+    {
+        var linkManager = await FindAsync(x => x.RunsOn.Equals(runsOn));
+
+        if (linkManager == null)
+        {
+            throw new EntityNotFoundException($"No links configured for {runsOn}");
+        }
+
+        return linkManager;
+    }
+
+    public async Task<LinkManager> FindAsync(PlatformOperatingSystem runsOn)
+    {
+        return await FindAsync(x => x.RunsOn.Equals(runsOn));
+    }
+
+    public async Task<LinkManager> InsertOrUpdateAsync(LinkManager linkManager)
+    {
+        var manager = await FindAsync(linkManager.RunsOn);
+
+        return manager == null
+            ? await InsertAsync(linkManager)
+            : await UpdateAsync(linkManager);
+    }
+}

--- a/test/FuseDigital.QuickSetup.Application.Tests/FuseDigital.QuickSetup.Application.Tests.csproj
+++ b/test/FuseDigital.QuickSetup.Application.Tests/FuseDigital.QuickSetup.Application.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <EmbeddedResource Include="LinkManagers\links.yml" />
     <EmbeddedResource Include="PackageManagers\packages.yml" />
     <EmbeddedResource Include="Projects\project-exists.yml" />
   </ItemGroup>

--- a/test/FuseDigital.QuickSetup.Application.Tests/LinkManagers/LinkCommandTests.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/LinkManagers/LinkCommandTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.LinkManagers.Dto;
+using FuseDigital.QuickSetup.Platforms;
+using FuseDigital.QuickSetup.Repositories;
+using FuseDigital.QuickSetup.Yaml;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Entities;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.LinkManagers;
+
+public class LinkCommandTests : QuickSetupApplicationTestBase
+{
+    [Fact]
+    public async Task Should_Only_Create_Links_For_Current_Platform()
+    {
+        // Arrange
+        var operatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+        var unsupportedOperatingSystems = Enum.GetValues<PlatformOperatingSystem>()
+            .Select(x => x != operatingSystem);
+
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new LinkManagerRepository(context);
+        await CopyFileAsync("links.yml", repository.FilePath);
+
+        var options = new LinkOptions();
+        var command = new LinkCommand(repository, shell, console)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        await command.ExecuteAsync(options);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync($"{operatingSystem} sample-directory .qup/sample-directory"))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync($"{operatingSystem} sample-file .qup/sample-file"))
+            .MustHaveHappened();
+
+        foreach (var platform in unsupportedOperatingSystems)
+        {
+            A.CallTo(() => shell.RunProcessAsync($"{platform} sample-directory .qup/sample-directory"))
+                .MustNotHaveHappened();
+            A.CallTo(() => shell.RunProcessAsync($"{platform} sample-file .qup/sample-file"))
+                .MustNotHaveHappened();
+        }
+    }
+
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_The_Current_Platform_Link_Manager_Can_Not_Be_Found()
+    {
+        // Arrange
+        var operatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+    
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new LinkManagerRepository(context);
+        await CopyFileAsync("links.yml", repository.FilePath);
+        await repository.DeleteAsync(x => x.RunsOn == operatingSystem);
+
+        var options = new LinkOptions();
+        var command = new LinkCommand(repository, shell, console)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+    
+        // Act
+        var exception = await Should.ThrowAsync<EntityNotFoundException>(async () =>
+        {
+            await command.ExecuteAsync(options);
+        });
+        
+        // Arrange
+        exception.ShouldNotBeNull();
+        exception.Message.ShouldContain(operatingSystem.ToString());
+    }
+    
+    
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_The_Link_Exists_Already()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+    
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new LinkManagerRepository(context);
+        await CopyFileAsync("links.yml", repository.FilePath);
+    
+        var options = new LinkOptions
+        {
+            Target = "sample-file",
+            Source = ".qup/sample-file",
+        };
+    
+        var command = new LinkCommand(repository, shell, console)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+    
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await command.ExecuteAsync(options);
+        });
+        
+        // Arrange
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("LM-001");
+    }
+    
+    [Fact]
+    public async Task Should_Add_Link_When_It_Does_Not_Exist()
+    {
+        // Arrange
+        var operatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+    
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new LinkManagerRepository(context);
+        await CopyFileAsync("links.yml", repository.FilePath);
+    
+        var options = new LinkOptions
+        {
+            Target = "a-new-file",
+            Source = ".a-folder/a-new-file"
+        };
+    
+        var command = new LinkCommand(repository, shell, console)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+    
+        // Act
+        await command.ExecuteAsync(options);
+    
+        // Arrange
+        A.CallTo(() => shell.RunProcessAsync($"{operatingSystem} {options.Target} {options.Source}"))
+            .MustHaveHappened();
+    
+        var manager = await repository.GetAsync(operatingSystem);
+        manager.Links
+            .Any(x => x.Target.Equals(options.Target) && x.Source.Equals(options.Source))
+            .ShouldBeTrue();
+    }
+    
+    [Fact]
+    public async Task Should_Not_Add_The_Link_When_The_Create_Failed()
+    {
+        // Arrange
+        var operatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+        var console = A.Fake<IConsoleService>();
+        var shell = A.Fake<IShellDomainService>();
+        A.CallTo(() => shell.RunProcessAsync(A<string[]>._))
+            .Returns(999);
+    
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new LinkManagerRepository(context);
+        await CopyFileAsync("links.yml", repository.FilePath);
+    
+        var options = new LinkOptions
+        {
+            Target = "a-new-file",
+            Source = ".a-folder/a-new-file"
+        };
+    
+        var command = new LinkCommand(repository, shell, console)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+    
+        // Act
+        await command.ExecuteAsync(options);
+    
+        // Arrange
+        var manager = await repository.GetAsync(operatingSystem);
+        manager.Links
+            .Any(x => x.Target.Equals(options.Target) && x.Source.Equals(options.Source))
+            .ShouldBeFalse();
+    }
+    
+    [Fact]
+    public async Task Should_Add_Link_Using_Default_Command_Format_When_No_Link_Manager_Found_For_Current_Operating_System()
+    {
+        // Arrange
+        var operatingSystem = PlatformEnvironment.CurrentOperatingSystem();
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+    
+        var context = GetRequiredService<IYamlContext>();
+        var repository = new LinkManagerRepository(context);
+    
+        var options = new LinkOptions
+        {
+            Target = "a-new-file",
+            Source = ".a-folder/a-new-file"
+        };
+    
+        var command = new LinkCommand(repository, shell, console)
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+    
+        // Act
+        await command.ExecuteAsync(options);
+    
+        // Arrange
+        A.CallTo(() => shell.RunProcessAsync(A<string[]>._))
+            .MustHaveHappened();
+    
+        var manager = await repository.GetAsync(operatingSystem);
+        manager.Links
+            .Any(x => x.Target.Equals(options.Target) && x.Source.Equals(options.Source))
+            .ShouldBeTrue();
+    }
+}

--- a/test/FuseDigital.QuickSetup.Application.Tests/LinkManagers/links.yml
+++ b/test/FuseDigital.QuickSetup.Application.Tests/LinkManagers/links.yml
@@ -1,0 +1,27 @@
+﻿- runs-on: macOS
+  description: A description for link manager for macOS
+  create-link-format: macOS ${target} ${source}
+  links:
+    - target: sample-directory
+      source: .qup/sample-directory
+    - target: sample-file
+      source: .qup/sample-file
+
+- runs-on: Linux
+  description: A description for link manager for Linux
+  create-link-format: Linux ${target} ${source}
+  links:
+    - target: sample-directory
+      source: .qup/sample-directory
+    - target: sample-file
+      source: .qup/sample-file
+
+- runs-on: Windows
+  description: A description for link manager for Windows
+  create-link-format: Windows ${target} ${source}
+  links:
+    - target: sample-directory
+      source: .qup/sample-directory
+    - target: sample-file
+      source: .qup/sample-file
+

--- a/test/FuseDigital.QuickSetup.Domain.Tests/LinkManagers/LinkManagerTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/LinkManagers/LinkManagerTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.Platforms;
+using Shouldly;
+using Volo.Abp;
+using Volo.Abp.Validation;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.LinkManagers;
+
+public class LinkManagerTests : QuickSetupDomainTestBase
+{
+    [Fact]
+    public async Task Should_Create_Links()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreateLinkManager();
+
+        // Act
+        await manager.CreateLinksAsync(shell, console);
+
+        // Assert
+        A.CallTo(() => shell.RunProcessAsync(manager.GenerateCreateLinkCommand(manager.Links[0])))
+            .MustHaveHappened();
+        A.CallTo(() => shell.RunProcessAsync(manager.GenerateCreateLinkCommand(manager.Links[1])))
+            .MustHaveHappened();
+    }
+
+    private static LinkManager CreateLinkManager()
+    {
+        return new LinkManager
+        {
+            RunsOn = PlatformEnvironment.CurrentOperatingSystem(),
+            CreateLinkFormat = "sudo ln -sfv ${source} ${target}",
+            Description = "Description for sample link manager",
+            Links = new List<Link>
+            {
+                new("source/file", "target/file"),
+                new("source/directory", "target/directory"),
+            }
+        };
+    }
+
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_Link_Manager_Is_Not_Configured_To_Run_On_Operating_System()
+    {
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = new LinkManager();
+        manager.RunsOn = Enum.GetValues<PlatformOperatingSystem>().First(x => x != manager.RunsOn);
+
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await manager.CreateLinksAsync(shell, console);
+        });
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("LM-001");
+    }
+
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_No_Create_Link_Format_Specified()
+    {
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreateLinkManager();
+        manager.CreateLinkFormat = null;
+
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await manager.CreateLinksAsync(shell, console);
+        });
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("LM-002");
+    }
+
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_Create_Link_Format_Does_Not_Contain_Source_Placeholder()
+    {
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreateLinkManager();
+        manager.CreateLinkFormat = "ln {source} ${target}";
+
+
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await manager.CreateLinksAsync(shell, console);
+        });
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("LM-003");
+    }
+
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_Create_Link_Format_Does_Not_Contain_Target_Placeholder()
+    {
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreateLinkManager();
+        manager.CreateLinkFormat = "ln ${source} {target}";
+
+        // Act
+        var exception = await Should.ThrowAsync<BusinessException>(async () =>
+        {
+            await manager.CreateLinksAsync(shell, console);
+        });
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.Code.ShouldBe("LM-004");
+    }
+
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_No_Source_For_Link_Provided()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreateLinkManager();
+        var link = new Link(null, "target");
+
+        // Act
+        var exception = await Should.ThrowAsync<AbpValidationException>(async () =>
+        {
+            await manager.AddLinkAsync(link, shell, console);
+        });
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.ValidationErrors.First().MemberNames.ShouldContain("Source");
+    }
+
+    [Fact]
+    public async Task Should_Throw_An_Exception_When_No_Target_For_Link_Provided()
+    {
+        // Arrange
+        var shell = A.Fake<IShellDomainService>();
+        var console = A.Fake<IConsoleService>();
+        var manager = CreateLinkManager();
+        var link = new Link("source", "");
+
+        // Act
+        var exception = await Should.ThrowAsync<AbpValidationException>(async () =>
+        {
+            await manager.AddLinkAsync(link, shell, console);
+        });
+
+        // Assert
+        exception.ShouldNotBeNull();
+        exception.ValidationErrors.First().MemberNames.ShouldContain("Target");
+    }
+}


### PR DESCRIPTION

### Add entity keys abstraction

Added a new QupEntity abstract class that uses the reflection to return
a list of all property with the `[Key]` attribute for the required
 `GetKeys` method.

Extracted entity model validation from the YAML repository into an
extension methods that allow the domain model to perform entity model
validation when required.

### Add validation exception handling

Updated the application service exception handling to also handle and
log `AbpValidationException` exceptions automatically.

### Implement `link` command

The link command helps users easily create and track symbolic links per
platform. It has options for specifying a source and target file or
directory to create a new link, or for creating all links for the
current platform.
