### PR TITLE
Implement `fetch` command

### DIFF
--- a/src/FuseDigital.QuickSetup.Application/Projects/Dto/CloneOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/Projects/Dto/CloneOptions.cs
@@ -1,15 +1,25 @@
 using System;
 using CommandLine;
+using CommandLine.Text;
 
 namespace FuseDigital.QuickSetup.Projects.Dto;
 
-[Verb("clone", HelpText = "The clone command allows you to download a copy of a Git source repository to your local machine. It automatically saves the repository information and sets up synchronization, so that you can easily work with the repository across multiple machines.")]
+[Verb("clone",
+    HelpText =
+        "The clone command allows you to download a copy of a Git source repository to your local machine. " +
+        "It automatically saves the repository information and sets up synchronization, so that you can easily work " +
+        "with the repository across multiple machines."
+)]
 public class CloneOptions : QupCommandOptions
 {
     [Value(0, MetaName = "repository", Required = true, HelpText = "The URL of the repository to clone.")]
     public string Repository { get; set; }
-    
-    [Value(1, MetaName = "path", Required = true, HelpText = "The local path where the repository will be cloned. This can be an absolute or relative path, and the ~ character can be used to represent the user profile folder (which is platform-agnostic).")]
+
+    [Value(1, MetaName = "path", Required = true,
+        HelpText =
+            "The local path where the repository will be cloned. This can be an absolute or relative path, and the " +
+            "~ character can be used to represent the user profile folder (which is platform-agnostic)."
+    )]
     public string LocalFolder { get; set; }
 
     public override Type GetCommandType()

--- a/src/FuseDigital.QuickSetup.Application/Projects/Dto/FetchOptions.cs
+++ b/src/FuseDigital.QuickSetup.Application/Projects/Dto/FetchOptions.cs
@@ -1,0 +1,18 @@
+using System;
+using CommandLine;
+
+namespace FuseDigital.QuickSetup.Projects.Dto;
+
+[Verb("fetch",
+    HelpText = "The fetch command clones or pulls all the repositories in the projects file in your local " +
+               "environment. If a repository does not exist locally, it will be cloned from the remote repository. " +
+               "If the repository already exists locally, a `git pull` will be performed to update it with the " +
+               "latest changes."
+)]
+public class FetchOptions : QupCommandOptions
+{
+    public override Type GetCommandType()
+    {
+        return typeof(FetchCommand);
+    }
+}

--- a/src/FuseDigital.QuickSetup.Application/Projects/FetchCommand.cs
+++ b/src/FuseDigital.QuickSetup.Application/Projects/FetchCommand.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FuseDigital.QuickSetup.Platforms;
+using FuseDigital.QuickSetup.VersionControlSystems;
+using Volo.Abp.DependencyInjection;
+
+namespace FuseDigital.QuickSetup.Projects;
+
+public class FetchCommand : QupCommandAsync, ITransientDependency
+{
+    private readonly IProjectRepository _repository;
+    private readonly IVersionControlDomainService _sourceControl;
+    private readonly IConsoleService _console;
+
+    public FetchCommand(IProjectRepository repository,
+        IVersionControlDomainService sourceControl,
+        IConsoleService console)
+    {
+        _repository = repository;
+        _sourceControl = sourceControl;
+        _console = console;
+    }
+
+    public override async Task ExecuteAsync(IQupCommandOptions options)
+    {
+        await base.ExecuteAsync(options);
+
+        await _console.WriteTitleAsync("fetch");
+
+        var projects = await _repository.GetListAsync();
+        for (var index = 0; index < projects.Count; index++)
+        {
+            var project = projects[index];
+
+            await _console.WriteLineAsync();
+            await _console.WriteLineAsync("[{0}/{1}] - Fetching {2}", index + 1, projects.Count, project.RelativePath);
+
+            project.Fetch(_sourceControl);
+        }
+    }
+}

--- a/src/FuseDigital.QuickSetup.Domain/Projects/Project.cs
+++ b/src/FuseDigital.QuickSetup.Domain/Projects/Project.cs
@@ -6,13 +6,24 @@ namespace FuseDigital.QuickSetup.Projects;
 
 public class Project : QupEntity
 {
-    [Key]
-    public string RelativePath { get; set; }
+    [Key] public string RelativePath { get; set; }
 
     public string Repository { get; set; }
 
     public void Clone(IVersionControlDomainService versionControl)
     {
         versionControl.Clone(Repository, RelativePath);
+    }
+
+    public void Fetch(IVersionControlDomainService versionControl)
+    {
+        if (versionControl.Exists(RelativePath))
+        {
+            versionControl.Fetch();
+        }
+        else
+        {
+            versionControl.Clone(Repository, RelativePath);
+        }
     }
 }

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/IVersionControlDomainService.cs
@@ -8,6 +8,8 @@ public interface IVersionControlDomainService : IDomainService
 
     string RepositoryDirectory { get; }
 
+    bool Exists(string relativePath, bool setWorkingDirectoryIfExists = true);
+
     IEnumerable<string> Clone(string sourceUrl, string relativePath);
 
     IEnumerable<string> Init(string workingDirectory,

--- a/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
+++ b/src/FuseDigital.QuickSetup.Domain/VersionControlSystems/VersionControlDomainService.cs
@@ -20,6 +20,21 @@ public class VersionControlDomainService : DomainService, IVersionControlDomainS
         _options = options.Value;
     }
 
+    public bool Exists(string relativePath, bool setWorkingDirectoryIfExists = true)
+    {
+        Check.NotNullOrEmpty(relativePath, nameof(relativePath));
+
+        var workingDirectory = _options.GetAbsolutePath(relativePath);
+        var exists = Directory.Exists(Path.Combine(workingDirectory, RepositoryDirectory));
+
+        if (exists && setWorkingDirectoryIfExists)
+        {
+            WorkingDirectory = workingDirectory;
+        }
+
+        return exists;
+    }
+
     public IEnumerable<string> Clone(string sourceUrl, string relativePath)
     {
         Check.NotNullOrEmpty(sourceUrl, nameof(sourceUrl));

--- a/test/FuseDigital.QuickSetup.Application.Tests/Projects/FetchCommandTests.cs
+++ b/test/FuseDigital.QuickSetup.Application.Tests/Projects/FetchCommandTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FuseDigital.QuickSetup.Platforms;
+using FuseDigital.QuickSetup.Projects.Dto;
+using FuseDigital.QuickSetup.Repositories;
+using FuseDigital.QuickSetup.VersionControlSystems;
+using FuseDigital.QuickSetup.Yaml;
+using Volo.Abp.DependencyInjection;
+using Xunit;
+
+namespace FuseDigital.QuickSetup.Projects;
+
+public class FetchCommandTests : QuickSetupApplicationTestBase
+{
+    private readonly string _basePath;
+
+    public FetchCommandTests()
+    {
+        _basePath = Guid.NewGuid().ToString();
+    }
+
+    [Fact]
+    public async Task Should_Clone_Project_If_It_Does_Not_Exist()
+    {
+        // Arrange
+        var repository = GetRepository();
+        await CopyFileAsync("project-exists.yml", repository.FilePath);
+
+        var versionControl = A.Fake<IVersionControlDomainService>();
+        A.CallTo(() => versionControl.Exists(A<string>._, A<bool>._))
+            .Returns(false);
+
+        var command = new FetchCommand(repository, versionControl, A.Fake<IConsoleService>())
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        await command.ExecuteAsync(new FetchOptions());
+
+        // Assert
+        A.CallTo(() => versionControl.Clone(A<string>._, A<string>._))
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task Should_Fetch_Project_If_It_Does_Exist()
+    {
+        // Arrange
+        var repository = GetRepository();
+        await CopyFileAsync("project-exists.yml", repository.FilePath);
+
+        var versionControl = A.Fake<IVersionControlDomainService>();
+        A.CallTo(() => versionControl.Exists(A<string>._, A<bool>._))
+            .Returns(true);
+
+        var command = new FetchCommand(repository, versionControl, A.Fake<IConsoleService>())
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>(),
+        };
+
+        // Act
+        await command.ExecuteAsync(new FetchOptions());
+
+        // Assert
+        A.CallTo(() => versionControl.Fetch(null))
+            .MustHaveHappened();
+    }
+
+    private ProjectRepository GetRepository(IYamlContext context = default)
+    {
+        return new ProjectRepository(context ?? GetContext(_basePath))
+        {
+            LazyServiceProvider = GetService<IAbpLazyServiceProvider>()
+        };
+    }
+
+    public override void Dispose()
+    {
+        var context = GetRequiredService<IYamlContext>();
+        var path = Path.Combine(context.Options.UserProfile, _basePath);
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, true);
+        }
+
+        base.Dispose();
+    }
+}

--- a/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
+++ b/test/FuseDigital.QuickSetup.Domain.Tests/VersionControlSystems/VersionControlSystemTests.cs
@@ -30,6 +30,31 @@ public sealed class VersionControlSystemTests : QuickSetupDomainTestBase
         RemoteUrl = Settings.GetAbsolutePath($"~/server/dot-files.git");
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Exist_Should_Check_If_Repository_Already_Exists_And_Set_Working_Directory(bool setWorkingDirectory)
+    {
+        // Arrange
+        LogDebug();
+        _versionControlSystem.Init(RemoteUrl, new[] { "--bare", "-b", BranchName });
+        _versionControlSystem.Clone(RemoteUrl, RepoRelativePath);
+        
+        // Act
+        var exist = _versionControlSystem.Exists(RepoRelativePath, setWorkingDirectory);
+
+        // Assert
+        exist.ShouldBeTrue();
+        if (!setWorkingDirectory)
+        {
+            _versionControlSystem.WorkingDirectory.ShouldBeNull();
+        }
+        else
+        {
+            _versionControlSystem.WorkingDirectory.ShouldNotBeNullOrEmpty();
+        }
+    }
+
     [Fact]
     public void Clone_Should_Create_Repository_In_Working_Directory()
     {


### PR DESCRIPTION
### Implement check if the repository exists

Implemented an operation to check if the repository does exist and set
the working directory is specified.

### Add fetch command to clone and pull project repositories

This commit adds a new command `qup fetch` that reads the projects file
in the user profile folder and clones all the repositories that are not
present in the local environment. If a repository already exists, it
performs a `git fetch` operation to update it to the latest version.

This command is useful for quickly setting up a new development
environment with all the required repositories without having to
manually clone each one individually.

The command also has an optional verbosity parameter that controls the
level of output to the console and log file.
