### PR TITLE
Fix version number and pack output folder

### DIFF
--- a/.github/actions/dotnet/pack/action.yml
+++ b/.github/actions/dotnet/pack/action.yml
@@ -2,6 +2,9 @@ name: pack
 description: 'Packs and sign the code into a NuGet package'
 
 inputs:
+  project:
+    description: 'The project file that needs to be packed'
+    required: true
   dotnet-build-configuration:
     default: Release
     description: 'Defines the build configuration. The default for most projects is Release.'
@@ -18,11 +21,11 @@ runs:
   steps:
     - name: Pack pre-release version ${{steps.version.outputs.nuGetVersionV2}}
       shell: bash
-      run: dotnet pack --configuration ${{ inputs.dotnet-build-configuration }} --verbosity normal --no-restore -p:PackageVersion=${{ inputs.pre-release-version }} --output ./packages/preview
+      run: dotnet pack ${{ inputs.project }} --configuration ${{ inputs.dotnet-build-configuration }} --verbosity normal --no-restore -p:PackageVersion=${{ inputs.pre-release-version }} --output ./packages/preview
 
     - name: Pack release version ${{steps.version.outputs.majorMinorPatch}}
       shell: bash
-      run: dotnet pack --configuration ${{ inputs.dotnet-build-configuration }} --verbosity normal --no-restore -p:PackageVersion=${{ inputs.release-version }} --output ./packages/release
+      run: dotnet pack ${{ inputs.project }} --configuration ${{ inputs.dotnet-build-configuration }} --verbosity normal --no-restore -p:PackageVersion=${{ inputs.release-version }} --output ./packages/release
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,6 @@ jobs:
         uses: './.github/actions/dotnet/pack'
         if: ${{ inputs.pack }}
         with:
+          project: ./src/FuseDigital.QuickSetup.Cli/FuseDigital.QuickSetup.Cli.csproj
           pre-release-version: ${{steps.version.outputs.pre-release-version}}
           release-version: ${{steps.version.outputs.release-version}}

--- a/src/FuseDigital.QuickSetup.Application/QuickSetupAppService.cs
+++ b/src/FuseDigital.QuickSetup.Application/QuickSetupAppService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -27,7 +26,8 @@ public class QuickSetupAppService : ApplicationService
 
     public async Task RunAsync(IEnumerable<string> args)
     {
-        Logger.LogInformation("Quick Setup ({ProductVersion}) (https://github.com/fuse-digital/quick-setup)", GetProductVersion());
+        Logger.LogInformation("Quick Setup ({ProductVersion}) (https://github.com/fuse-digital/quick-setup)",
+            GetProductVersion());
         Logger.LogDebug("User profile directory is set {UserProfile}", Settings.UserProfile);
         Logger.LogDebug("The base directory for QUP is set {BaseDirectory}", Settings.BaseDirectory);
 
@@ -52,9 +52,8 @@ public class QuickSetupAppService : ApplicationService
 
     private string GetProductVersion()
     {
-        var assembly = Assembly.GetEntryAssembly();
-        var version = FileVersionInfo.GetVersionInfo(assembly.Location);
-        return version.ProductVersion;
+        var version = Assembly.GetEntryAssembly()?.GetName().Version;
+        return version?.ToString();
     }
 
     private Task DisplayHelpAsync<T>(ParserResult<T> result, IEnumerable<Error> errors)
@@ -79,12 +78,13 @@ public class QuickSetupAppService : ApplicationService
             }, e => e);
             Console.WriteLine(helpText);
         }
+
         return Task.CompletedTask;
     }
 
     private async Task RunCommandAsync(IQupCommandOptions options)
     {
-        var command = (IQupCommandAsync) LazyServiceProvider.LazyGetRequiredService(options.GetCommandType());
+        var command = (IQupCommandAsync)LazyServiceProvider.LazyGetRequiredService(options.GetCommandType());
         await command.ExecuteAsync(options);
     }
 


### PR DESCRIPTION
### Fix the version number.

### Fix output folder error

The `--output` is not supported when building a solution anymore. Fix
this by specifying the project file that needs to be packed.
